### PR TITLE
define interface de gatway File

### DIFF
--- a/application/src/main/java/org/osnormais/storage/api/application/file/FileCommandGateway.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/file/FileCommandGateway.java
@@ -1,0 +1,9 @@
+package org.osnormais.storage.api.application.file;
+
+import org.osnormais.storage.api.domain.file.File;
+
+public interface FileCommandGateway {
+
+    void create(File file);
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/file/FileQueryGateway.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/file/FileQueryGateway.java
@@ -7,6 +7,6 @@ import org.osnormais.storage.api.domain.file.FileId;
 
 public interface FileQueryGateway {
 
-    Optional<File> findByid(FileId id);
+    Optional<File> findById(FileId id);
 
 }

--- a/application/src/main/java/org/osnormais/storage/api/application/file/FileQueryGateway.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/file/FileQueryGateway.java
@@ -1,0 +1,12 @@
+package org.osnormais.storage.api.application.file;
+
+import java.util.Optional;
+
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+
+public interface FileQueryGateway {
+
+    Optional<File> findByid(FileId id);
+
+}


### PR DESCRIPTION
Este PR implementa a separação dos Gateways de Command e Query
para o agregado `File`, seguindo o padrão CQRS, conforme definido na Issue #5. Ou seja, implementa separação de gateways command/query. O objetivo é melhorar a separação de responsabilidades, reduzir acoplamento e manter alinhamento com os princípios
do Clean Architecture.

---

## 🛠️ O que foi feito

- Definido o contrato de uso
- Criada interface `FileCommandGateway`
- Criada interface `FileQueryGateway`
O que falta fazer:
- Implementar as classes concretas na camada de infraestrutura
- Implementar o UseCases de File para depender apenas das interfaces

---

## 🧱 Decisões Arquiteturais

- Aplicado padrão **CQRS**
- Aplicado princípio da **Responsabilidade Única (SRP)**
- Aplicado princípio da **Inversão de Dependência (DIP)**
- A camada de domínio depende apenas de abstrações
- A camada de infraestrutura implementa os contratos

Essa separação facilita manutenção, testes e futura escalabilidade.
O CQRS (Command Query Responsibility Segregation) é um padrão utilizado para separar as responsabilidades de leitura e escrita nos bancos de dados. E com isso é possível evitar problemas de incompatibilidade e inconsistência nas informações.
