### PR TITLE
Feature/upload transfer channel

### DIFF
--- a/application/src/main/java/org/osnormais/storage/api/application/exception/ApplicationException.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/exception/ApplicationException.java
@@ -1,0 +1,61 @@
+package org.osnormais.storage.api.application.exception;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ApplicationException extends RuntimeException {
+
+    private final List<ApplicationException.Error> errors;
+
+    protected ApplicationException(
+            final String message,
+            final List<ApplicationException.Error> errors,
+            final Throwable cause,
+            final boolean verbose) {
+        super(message, cause, enableSuppression(verbose), writableStackTrace(verbose));
+        this.errors = addCauseToErrors(errors, cause) == null ? List.of() : new ArrayList<>(errors);
+    }
+
+    public List<ApplicationException.Error> getErrors() {
+        return List.copyOf(errors);
+    }
+
+    public String errorsToString() {
+        return "[" + errors.stream()
+                .map(ApplicationException.Error::message)
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("No errors") + "]";
+    }
+
+    private static boolean enableSuppression(final boolean verbose) {
+        return !verbose;
+    }
+
+    private static boolean writableStackTrace(final boolean verbose) {
+        return verbose;
+    }
+
+    private static List<ApplicationException.Error> addCauseToErrors(
+            final List<ApplicationException.Error> errors,
+            final Throwable cause) {
+        if (cause == null)
+            return errors;
+
+        final List<ApplicationException.Error> result = new ArrayList<>(errors != null ? errors : List.of());
+        result.add(ApplicationException.Error.with(cause));
+        return result;
+    }
+
+    public record Error(String message) {
+
+        public static ApplicationException.Error with(final String message) {
+            return new ApplicationException.Error(message);
+        }
+
+        public static ApplicationException.Error with(final Throwable cause) {
+            return new ApplicationException.Error(
+                    "Exception:[" + cause.getClass().getName() + "] Message:[" + cause.getMessage() + "]");
+        }
+
+    }
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/exception/NotFoundException.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/exception/NotFoundException.java
@@ -1,0 +1,45 @@
+package org.osnormais.storage.api.application.exception;
+
+import java.util.List;
+
+import org.osnormais.storage.api.domain.Entity;
+import org.osnormais.storage.api.domain.Identifier;
+
+public class NotFoundException extends SilentApplicationException {
+
+    private static final String MESSAGE_TEMPLATE = "[%S] not found";
+    private static final String ERROR_TEMPLATE = "[%s] with id [%s] not found";
+
+    private <E extends Entity<I>, I extends Identifier<?>> NotFoundException(
+            final Class<E> entityClass,
+            final I identifier) {
+        super(
+                MESSAGE_TEMPLATE.formatted(entityClass.getSimpleName()),
+                List.of(Error.with(
+                        ERROR_TEMPLATE.formatted(
+                                entityClass.getSimpleName(),
+                                identifier.getStringValue()))));
+    }
+
+    private <E extends Entity<I>, I extends Identifier<?>> NotFoundException(final Class<E> entityClass) {
+        super(
+                MESSAGE_TEMPLATE.formatted(entityClass.getSimpleName()),
+                List.of(Error.with(MESSAGE_TEMPLATE.formatted(entityClass.getSimpleName()))));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E extends Entity<I>, I extends Identifier<?>> NotFoundException create(final Entity<I> entity) {
+        return new NotFoundException(entity.getClass(), entity.getId());
+    }
+
+    public static <E extends Entity<I>, I extends Identifier<?>> NotFoundException create(
+            final Class<E> entityClass,
+            final I identifier) {
+        return new NotFoundException(entityClass, identifier);
+    }
+
+    public static <E extends Entity<I>, I extends Identifier<?>> NotFoundException create(final Class<E> entityClass) {
+        return new NotFoundException(entityClass);
+    }
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/exception/SilentApplicationException.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/exception/SilentApplicationException.java
@@ -1,0 +1,26 @@
+package org.osnormais.storage.api.application.exception;
+
+import java.util.List;
+
+public abstract class SilentApplicationException extends ApplicationException {
+
+    private static final boolean VERBOSE = false;
+
+    protected SilentApplicationException(final String message) {
+        super(message, null, null, VERBOSE);
+    }
+
+    protected SilentApplicationException(
+            final String message,
+            final List<ApplicationException.Error> errors) {
+        super(message, errors, null, VERBOSE);
+    }
+
+    protected SilentApplicationException(
+            final String message,
+            final List<ApplicationException.Error> errors,
+            final Throwable cause) {
+        super(message, errors, cause, VERBOSE);
+    }
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/gateway/file/FileCommandGateway.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/gateway/file/FileCommandGateway.java
@@ -1,4 +1,4 @@
-package org.osnormais.storage.api.application.file;
+package org.osnormais.storage.api.application.gateway.file;
 
 import org.osnormais.storage.api.domain.file.File;
 

--- a/application/src/main/java/org/osnormais/storage/api/application/gateway/file/FileCommandGateway.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/gateway/file/FileCommandGateway.java
@@ -6,4 +6,6 @@ public interface FileCommandGateway {
 
     void create(File file);
 
+    File update(File file);
+
 }

--- a/application/src/main/java/org/osnormais/storage/api/application/gateway/file/FileCommandGateway.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/gateway/file/FileCommandGateway.java
@@ -4,7 +4,7 @@ import org.osnormais.storage.api.domain.file.File;
 
 public interface FileCommandGateway {
 
-    void create(File file);
+    File create(File file);
 
     File update(File file);
 

--- a/application/src/main/java/org/osnormais/storage/api/application/gateway/file/FileQueryGateway.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/gateway/file/FileQueryGateway.java
@@ -1,4 +1,4 @@
-package org.osnormais.storage.api.application.file;
+package org.osnormais.storage.api.application.gateway.file;
 
 import java.util.Optional;
 

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/CreateFileUploadTransferChannelInput.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/CreateFileUploadTransferChannelInput.java
@@ -1,0 +1,11 @@
+package org.osnormais.storage.api.application.usecase.file.transferchannel.upload.create;
+
+import java.util.UUID;
+
+public record CreateFileUploadTransferChannelInput(
+        UUID fileId,
+        Long throughputBytesLimit,
+        Long chunkBytesSize,
+        Integer maxParallelChunks) {
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/CreateFileUploadTransferChannelOutput.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/CreateFileUploadTransferChannelOutput.java
@@ -1,0 +1,11 @@
+package org.osnormais.storage.api.application.usecase.file.transferchannel.upload.create;
+
+import java.util.UUID;
+
+public record CreateFileUploadTransferChannelOutput(
+        UUID fileId,
+        Long totalChunks,
+        Long chunkBytesSize,
+        Long lastChunkBytesSize) {
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/CreateFileUploadTransferChannelUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/CreateFileUploadTransferChannelUseCase.java
@@ -1,0 +1,8 @@
+package org.osnormais.storage.api.application.usecase.file.transferchannel.upload.create;
+
+import org.osnormais.storage.api.application.usecase.UseCase;
+
+public abstract class CreateFileUploadTransferChannelUseCase
+        extends UseCase<CreateFileUploadTransferChannelInput, CreateFileUploadTransferChannelOutput> {
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import org.osnormais.storage.api.application.exception.NotFoundException;
 import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
 import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
+import org.osnormais.storage.api.domain.exception.ValidationException;
 import org.osnormais.storage.api.domain.file.File;
 import org.osnormais.storage.api.domain.file.FileId;
 import org.osnormais.storage.api.domain.file.valueobject.ChunkSpecification;
@@ -38,10 +39,17 @@ public class DefaultCreateFileUploadTransferChannelUseCase extends CreateFileUpl
         fileId.validate(handler);
         transferChannel.validate(handler);
 
+        if (handler.hasErrors())
+            throw ValidationException.with("Invalid input values", handler);
+
         final File file = fileQueryGateway
                 .findById(fileId)
-                .orElseThrow(() -> NotFoundException.create(File.class, fileId))
-                .openUploadChannel(transferChannel);
+                .orElseThrow(() -> NotFoundException.create(File.class, fileId));
+
+        handler.validate(() -> file.openUploadChannel(transferChannel));
+
+        if (handler.hasErrors())
+            throw ValidationException.with("Failed to open upload transfer channel", handler);
 
         fileCommandGateway.update(file);
 

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
@@ -65,9 +65,9 @@ public class DefaultCreateFileUploadTransferChannelUseCase extends CreateFileUpl
 
         final ThroughputLimit throughputLimit = ThroughputLimit.create(input.throughputBytesLimit());
 
-        final Size chunkSpecificationSize = new Size(input.chunkBytesSize());
-        final ParallelChunkLimit chunkSpecificationParallelChunkLimit = new ParallelChunkLimit(
-                input.maxParallelChunks());
+        final Size chunkSpecificationSize = Size.of(input.chunkBytesSize());
+        final ParallelChunkLimit chunkSpecificationParallelChunkLimit = ParallelChunkLimit
+                .of(input.maxParallelChunks());
 
         final ChunkSpecification chunkSpecification = ChunkSpecification
                 .create(

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
@@ -1,0 +1,73 @@
+package org.osnormais.storage.api.application.usecase.file.transferchannel.upload.create;
+
+import static java.util.Objects.requireNonNull;
+
+import org.osnormais.storage.api.application.exception.NotFoundException;
+import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
+import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+import org.osnormais.storage.api.domain.file.valueobject.ChunkSpecification;
+import org.osnormais.storage.api.domain.file.valueobject.ParallelChunkLimit;
+import org.osnormais.storage.api.domain.file.valueobject.Size;
+import org.osnormais.storage.api.domain.file.valueobject.ThroughputLimit;
+import org.osnormais.storage.api.domain.file.valueobject.TransferChannel;
+import org.osnormais.storage.api.domain.validation.handler.Notification;
+import org.osnormais.storage.api.domain.validation.handler.ValidationHandler;
+
+public class DefaultCreateFileUploadTransferChannelUseCase extends CreateFileUploadTransferChannelUseCase {
+
+    private final FileQueryGateway fileQueryGateway;
+    private final FileCommandGateway fileCommandGateway;
+
+    public DefaultCreateFileUploadTransferChannelUseCase(
+            final FileQueryGateway fileQueryGateway,
+            final FileCommandGateway fileCommandGateway) {
+        this.fileQueryGateway = requireNonNull(fileQueryGateway);
+        this.fileCommandGateway = requireNonNull(fileCommandGateway);
+    }
+
+    @Override
+    public CreateFileUploadTransferChannelOutput execute(final CreateFileUploadTransferChannelInput input) {
+
+        final ValidationHandler handler = Notification.create();
+
+        final FileId fileId = FileId.of(input.fileId());
+        final TransferChannel transferChannel = createTransferChannel(input);
+
+        fileId.validate(handler);
+        transferChannel.validate(handler);
+
+        final File file = fileQueryGateway
+                .findById(fileId)
+                .orElseThrow(() -> NotFoundException.create(File.class, fileId))
+                .openUploadChannel(transferChannel);
+
+        fileCommandGateway.update(file);
+
+        return new CreateFileUploadTransferChannelOutput(
+                file.getId().getValue(),
+                transferChannel.chunkSpecification().totalChunks(file.getSize()),
+                transferChannel.chunkSpecification().chunkBytesSize(file.getSize()).bytes(),
+                transferChannel.chunkSpecification().lastChunkSize(file.getSize()).bytes());
+
+    }
+
+    private static TransferChannel createTransferChannel(final CreateFileUploadTransferChannelInput input) {
+
+        final ThroughputLimit throughputLimit = ThroughputLimit.create(input.throughputBytesLimit());
+
+        final Size chunkSpecificationSize = new Size(input.chunkBytesSize());
+        final ParallelChunkLimit chunkSpecificationParallelChunkLimit = new ParallelChunkLimit(
+                input.maxParallelChunks());
+
+        final ChunkSpecification chunkSpecification = ChunkSpecification
+                .create(
+                        chunkSpecificationSize,
+                        chunkSpecificationParallelChunkLimit);
+
+        return TransferChannel.create(throughputLimit, chunkSpecification);
+
+    }
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
@@ -56,7 +56,7 @@ public class DefaultCreateFileUploadTransferChannelUseCase extends CreateFileUpl
         return new CreateFileUploadTransferChannelOutput(
                 file.getId().getValue(),
                 transferChannel.chunkSpecification().totalChunks(file.getSize()),
-                transferChannel.chunkSpecification().chunkBytesSize(file.getSize()).bytes(),
+                transferChannel.chunkSpecification().effectiveChunkSize(file.getSize()).bytes(),
                 transferChannel.chunkSpecification().lastChunkSize(file.getSize()).bytes());
 
     }

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
@@ -1,0 +1,219 @@
+package org.osnormais.storage.api.application.usecase.file.transferchannel.upload.create;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.osnormais.storage.api.application.exception.NotFoundException;
+import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
+import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
+import org.osnormais.storage.api.domain.exception.ValidationException;
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+import org.osnormais.storage.api.domain.file.valueobject.ChunkSpecification;
+import org.osnormais.storage.api.domain.file.valueobject.ParallelChunkLimit;
+import org.osnormais.storage.api.domain.file.valueobject.Size;
+import org.osnormais.storage.api.domain.file.valueobject.ThroughputLimit;
+import org.osnormais.storage.api.domain.file.valueobject.TransferChannel;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultCreateFileUploadTransferChannelUseCaseTest {
+
+    @InjectMocks
+    DefaultCreateFileUploadTransferChannelUseCase useCase;
+
+    @Mock
+    FileQueryGateway fileQueryGateway;
+
+    @Mock
+    FileCommandGateway fileCommandGateway;
+
+    @Test
+    void givenAnValidInput_whenCallsExecute_thenShouldCreateUploadTransferChannel() {
+
+        final var expectedFileIdValue = UUID.randomUUID();
+        final var expectedThroughputBytesLimitValue = 1024L;
+        final var expectedChunkBytesSizeValue = 1024L;
+        final var expectedMaxParallelChunksValue = 2;
+
+        final var expectedTotalChunksValue = 3L;
+        final var expectedLastChunkBytesSizeValue = 2L;
+
+        final var expectedFileId = FileId.of(expectedFileIdValue);
+        final var expectedFileSizeValue = 2050L;
+        final var expectedFileSize = Size.of(expectedFileSizeValue);
+        final var expectedThroughputLimit = ThroughputLimit.create(expectedThroughputBytesLimitValue);
+        final var expectedChunkBytesSize = Size.of(expectedChunkBytesSizeValue);
+        final var expectedMaxParallelChunks = new ParallelChunkLimit(expectedMaxParallelChunksValue);
+        final var expectedChunkSpecification = ChunkSpecification.create(
+                expectedChunkBytesSize,
+                expectedMaxParallelChunks);
+
+        final var expectedTransferChannel = TransferChannel.create(expectedThroughputLimit, expectedChunkSpecification);
+
+        final var expectedChecksumValue = "checksumValue";
+        final var expectedChecksumAlgorithm = Checksum.Algorithm.MD5;
+        final var expectedCheckcum = Checksum.of(expectedChecksumValue, expectedChecksumAlgorithm);
+
+        final var expectedFile = File.with(
+                expectedFileId,
+                expectedFileSize,
+                expectedCheckcum,
+                null,
+                null);
+
+        when(fileQueryGateway.findById(eq(expectedFileId)))
+                .thenReturn(Optional.of(expectedFile));
+
+        when(fileCommandGateway.update(
+                argThat(file -> {
+                    assertEquals(expectedFileId, file.getId());
+                    assertEquals(expectedFileSize, file.getSize());
+                    assertEquals(expectedCheckcum, file.getChecksum());
+                    assertTrue(file.getUploadChannel().isPresent());
+                    assertEquals(expectedTransferChannel, file.getUploadChannel().get());
+                    return true;
+                })))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        final var input = new CreateFileUploadTransferChannelInput(
+                expectedFileIdValue,
+                expectedThroughputBytesLimitValue,
+                expectedChunkBytesSizeValue,
+                expectedMaxParallelChunksValue);
+
+        final var actualOutput = assertDoesNotThrow(() -> useCase.execute(input));
+
+        assertEquals(expectedFileIdValue, actualOutput.fileId());
+        assertEquals(expectedTotalChunksValue, actualOutput.totalChunks());
+        assertEquals(expectedChunkBytesSizeValue, actualOutput.chunkBytesSize());
+        assertEquals(expectedLastChunkBytesSizeValue, actualOutput.lastChunkBytesSize());
+
+    }
+
+    @Test
+    void givenANonExistentFileId_whenCallsExecute_thenShouldThrowsNotFoundException() {
+
+        final UUID expectedFileIdValue = UUID.randomUUID();
+        final Long expectedThroughputBytesLimit = 1024L;
+        final Long expectedChunkBytesSize = 1024L;
+        final Integer expectedMaxParallelChunks = 2;
+
+        final var expectedFileId = FileId.of(expectedFileIdValue);
+
+        final var expectedErrorsCount = 1;
+        final var expectedExceptionMessage = "[%S] not found".formatted(File.class.getSimpleName());
+        final var expectedErrorMessage = "[%s] with id [%s] not found".formatted(
+                File.class.getSimpleName(),
+                expectedFileId.getStringValue());
+
+        final var input = new CreateFileUploadTransferChannelInput(
+                expectedFileIdValue,
+                expectedThroughputBytesLimit,
+                expectedChunkBytesSize,
+                expectedMaxParallelChunks);
+
+        when(fileQueryGateway.findById(eq(expectedFileId)))
+                .thenReturn(Optional.empty());
+
+        final var actualException = assertThrows(NotFoundException.class, () -> useCase.execute(input));
+
+        assertEquals(expectedExceptionMessage, actualException.getMessage());
+        assertEquals(expectedErrorsCount, actualException.getErrors().size());
+        assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
+
+
+    }
+
+    @Test
+    void givenInvalidInputWithFileIdNull_whenCallsExecute_thenShouldThrowsValidationException() {
+
+        final var expectedExceptionMessage = "Invalid input values";
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = "'id' should not be null";
+
+        final UUID expectedFileIdValue = null;
+        final Long expectedThroughputBytesLimit = 1024L;
+        final Long expectedChunkBytesSize = 1024L;
+        final Integer expectedMaxParallelChunks = 2;
+
+        final var input = new CreateFileUploadTransferChannelInput(
+                expectedFileIdValue,
+                expectedThroughputBytesLimit,
+                expectedChunkBytesSize,
+                expectedMaxParallelChunks);
+
+        final var actualException = assertThrows(ValidationException.class, () -> useCase.execute(input));
+
+        assertEquals(expectedExceptionMessage, actualException.getMessage());
+        assertEquals(expectedErrorsCount, actualException.getErrors().size());
+        assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
+
+    }
+
+    @Test
+    void givenAFileWithUploadTransferChannelAlreadyOpen_whenCallsExecute_thenShouldThrowsValidationException() {
+
+        final var expectedExceptionMessage = "Failed to open upload transfer channel";
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = "Upload transfer channel already open, please close the current channel before opening a new one";
+
+        final var expectedFileIdValue = UUID.randomUUID();
+        final var expectedThroughputBytesLimitValue = 1024L;
+        final var expectedChunkBytesSizeValue = 1024L;
+        final var expectedMaxParallelChunksValue = 2;
+
+        final var expectedFileId = FileId.of(expectedFileIdValue);
+        final var expectedFileSizeValue = 2048L;
+        final var expectedFileSize = Size.of(expectedFileSizeValue);
+        final var expectedThroughputLimit = ThroughputLimit.create(expectedThroughputBytesLimitValue);
+        final var expectedChunkBytesSize = Size.of(expectedChunkBytesSizeValue);
+        final var expectedMaxParallelChunks = new ParallelChunkLimit(expectedMaxParallelChunksValue);
+        final var expectedChunkSpecification = ChunkSpecification.create(
+                expectedChunkBytesSize,
+                expectedMaxParallelChunks);
+
+        final var expectedChecksumValue = "checksumValue";
+        final var expectedChecksumAlgorithm = Checksum.Algorithm.MD5;
+        final var expectedCheckcum = Checksum.of(expectedChecksumValue, expectedChecksumAlgorithm);
+
+        final var transferChannel = TransferChannel.create(expectedThroughputLimit, expectedChunkSpecification);
+
+        final var file = File.with(
+                expectedFileId,
+                expectedFileSize,
+                expectedCheckcum,
+                transferChannel,
+                null);
+
+        when(fileQueryGateway.findById(eq(expectedFileId)))
+                .thenReturn(Optional.of(file));
+
+        final var input = new CreateFileUploadTransferChannelInput(
+                expectedFileIdValue,
+                expectedThroughputBytesLimitValue,
+                expectedChunkBytesSizeValue,
+                expectedMaxParallelChunksValue);
+
+        final var actualException = assertThrows(ValidationException.class, () -> useCase.execute(input));
+
+        assertEquals(expectedExceptionMessage, actualException.getMessage());
+        assertEquals(expectedErrorsCount, actualException.getErrors().size());
+        assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
+
+    }
+
+}

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
@@ -57,7 +57,7 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
         final var expectedFileSize = Size.of(expectedFileSizeValue);
         final var expectedThroughputLimit = ThroughputLimit.create(expectedThroughputBytesLimitValue);
         final var expectedChunkBytesSize = Size.of(expectedChunkBytesSizeValue);
-        final var expectedMaxParallelChunks = new ParallelChunkLimit(expectedMaxParallelChunksValue);
+        final var expectedMaxParallelChunks = ParallelChunkLimit.of(expectedMaxParallelChunksValue);
         final var expectedChunkSpecification = ChunkSpecification.create(
                 expectedChunkBytesSize,
                 expectedMaxParallelChunks);
@@ -135,7 +135,6 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
         assertEquals(expectedErrorsCount, actualException.getErrors().size());
         assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
 
-
     }
 
     @Test
@@ -181,7 +180,7 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
         final var expectedFileSize = Size.of(expectedFileSizeValue);
         final var expectedThroughputLimit = ThroughputLimit.create(expectedThroughputBytesLimitValue);
         final var expectedChunkBytesSize = Size.of(expectedChunkBytesSizeValue);
-        final var expectedMaxParallelChunks = new ParallelChunkLimit(expectedMaxParallelChunksValue);
+        final var expectedMaxParallelChunks = ParallelChunkLimit.of(expectedMaxParallelChunksValue);
         final var expectedChunkSpecification = ChunkSpecification.create(
                 expectedChunkBytesSize,
                 expectedMaxParallelChunks);

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
@@ -62,11 +62,12 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
                 expectedChunkBytesSize,
                 expectedMaxParallelChunks);
 
-        final var expectedTransferChannel = TransferChannel.create(expectedThroughputLimit, expectedChunkSpecification);
+        final var expectedTransferChannel = TransferChannel.create(expectedThroughputLimit,
+                expectedChunkSpecification);
 
         final var expectedChecksumValue = "checksumValue";
         final var expectedChecksumAlgorithm = Checksum.Algorithm.MD5;
-        final var expectedCheckcum = Checksum.of(expectedChecksumValue, expectedChecksumAlgorithm);
+        final var expectedCheckcum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
         final var expectedFile = File.with(
                 expectedFileId,
@@ -187,7 +188,7 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
 
         final var expectedChecksumValue = "checksumValue";
         final var expectedChecksumAlgorithm = Checksum.Algorithm.MD5;
-        final var expectedCheckcum = Checksum.of(expectedChecksumValue, expectedChecksumAlgorithm);
+        final var expectedCheckcum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
         final var transferChannel = TransferChannel.create(expectedThroughputLimit, expectedChunkSpecification);
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/exception/InvalidArgumentException.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/exception/InvalidArgumentException.java
@@ -1,0 +1,24 @@
+package org.osnormais.storage.api.domain.exception;
+
+import static java.util.Objects.isNull;
+
+import java.util.List;
+
+public class InvalidArgumentException extends SilentDomainException {
+
+    private static final String MESSAGE = "Invalid argument provided.";
+
+    protected InvalidArgumentException(final List<DomainException.Error> errors) {
+        super(MESSAGE, isNull(errors) ? List.of() : List.copyOf(errors));
+    }
+
+    public static InvalidArgumentException with(final DomainException.Error error) {
+        final List<DomainException.Error> list = isNull(error) ? List.of() : List.of(error);
+        return new InvalidArgumentException(list);
+    }
+
+    public static InvalidArgumentException with(final List<DomainException.Error> errors) {
+        return new InvalidArgumentException(errors);
+    }
+
+}

--- a/domain/src/main/java/org/osnormais/storage/api/domain/exception/UploadTransferChannelAlreadyOpennedException.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/exception/UploadTransferChannelAlreadyOpennedException.java
@@ -1,0 +1,18 @@
+package org.osnormais.storage.api.domain.exception;
+
+import java.util.List;
+
+public class UploadTransferChannelAlreadyOpennedException extends SilentDomainException {
+
+    private static final String MESSAGE = "Upload transfer channel already open";
+    private static final String ERROR = MESSAGE + ", please close the current channel before opening a new one";
+
+    private UploadTransferChannelAlreadyOpennedException() {
+        super(MESSAGE, List.of(Error.with(ERROR)));
+    }
+
+    public static UploadTransferChannelAlreadyOpennedException create() {
+        return new UploadTransferChannelAlreadyOpennedException();
+    }
+
+}

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
@@ -5,6 +5,9 @@ import static java.util.Objects.isNull;
 import java.util.Optional;
 
 import org.osnormais.storage.api.domain.AggregateRoot;
+import org.osnormais.storage.api.domain.exception.DomainException;
+import org.osnormais.storage.api.domain.exception.InvalidArgumentException;
+import org.osnormais.storage.api.domain.exception.UploadTransferChannelAlreadyOpennedException;
 import org.osnormais.storage.api.domain.exception.ValidationException;
 import org.osnormais.storage.api.domain.file.valueobject.Checksum;
 import org.osnormais.storage.api.domain.file.valueobject.Size;
@@ -83,6 +86,20 @@ public class File extends AggregateRoot<FileId> {
                 checksum,
                 null,
                 null);
+    }
+
+    public File openUploadChannel(final TransferChannel transferChannel) {
+
+        if (isNull(transferChannel))
+            throw InvalidArgumentException.with(DomainException.Error.with("'transferChannel' should not be null"));
+
+        if (this.uploadChannel.isPresent())
+            throw UploadTransferChannelAlreadyOpennedException.create();
+
+        this.uploadChannel = Optional.of(transferChannel);
+
+        return this;
+
     }
 
     private void selfValidate() {

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
@@ -100,4 +100,12 @@ public class File extends AggregateRoot<FileId> {
         return checksum;
     }
 
+    public Optional<TransferChannel> getUploadChannel() {
+        return uploadChannel;
+    }
+
+    public Optional<TransferChannel> getDownloadChannel() {
+        return downloadChannel;
+    }
+
 }

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
@@ -73,6 +73,18 @@ public class File extends AggregateRoot<FileId> {
 
     }
 
+    public static File create(
+            final FileId id,
+            final Size size,
+            final Checksum checksum) {
+        return new File(
+                id,
+                size,
+                checksum,
+                null,
+                null);
+    }
+
     private void selfValidate() {
         final Notification notification = Notification.create();
         validate(notification);

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/FileId.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/FileId.java
@@ -6,8 +6,9 @@ import org.osnormais.storage.api.domain.Identifier;
 
 public class FileId extends Identifier<UUID> {
 
-    public FileId(UUID id) {
+    private FileId(UUID id) {
         super(id);
+    }
 
     public static FileId of(final UUID id) {
         return new FileId(id);
@@ -15,7 +16,6 @@ public class FileId extends Identifier<UUID> {
 
     @Override
     public String getStringValue() {
-
         return id.toString();
     }
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/FileId.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/FileId.java
@@ -9,6 +9,8 @@ public class FileId extends Identifier<UUID> {
     public FileId(UUID id) {
         super(id);
 
+    public static FileId of(final UUID id) {
+        return new FileId(id);
     }
 
     @Override

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Checksum.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Checksum.java
@@ -16,6 +16,10 @@ public record Checksum(Algorithm algorithm, String value) implements ValueObject
 
     }
 
+    public static Checksum of(final String value, final Algorithm algorithm) {
+        return new Checksum(algorithm, value);
+    }
+
     @Override
     public void validate(final ValidationHandler handler) {
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Checksum.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Checksum.java
@@ -16,7 +16,7 @@ public record Checksum(Algorithm algorithm, String value) implements ValueObject
 
     }
 
-    public static Checksum of(final String value, final Algorithm algorithm) {
+    public static Checksum of(final Algorithm algorithm, final String value) {
         return new Checksum(algorithm, value);
     }
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecification.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecification.java
@@ -10,6 +10,12 @@ public record ChunkSpecification(
         Size size,
         ParallelChunkLimit maxParallel) implements ValueObject {
 
+    public static ChunkSpecification create(
+            Size size,
+            ParallelChunkLimit maxParallel) {
+        return new ChunkSpecification(size, maxParallel);
+    }
+
     @Override
     public void validate(final ValidationHandler handler) {
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecification.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecification.java
@@ -31,6 +31,10 @@ public record ChunkSpecification(
 
     }
 
+    public Size chunkBytesSize(final Size fileSize) {
+        return size.bytes() > fileSize.bytes() ? fileSize : size;
+    }
+
     public Size lastChunkSize(final Size fileSize) {
 
         final long hasPartialChunk = fileSize.bytes() % size.bytes() != 0 ? 1 : 0;

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecification.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecification.java
@@ -31,7 +31,7 @@ public record ChunkSpecification(
 
     }
 
-    public Size chunkBytesSize(final Size fileSize) {
+    public Size effectiveChunkSize(final Size fileSize) {
         return size.bytes() > fileSize.bytes() ? fileSize : size;
     }
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ParallelChunkLimit.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ParallelChunkLimit.java
@@ -6,6 +6,10 @@ import org.osnormais.storage.api.domain.validation.handler.ValidationHandler;
 
 public record ParallelChunkLimit(int value) implements ValueObject {
 
+    public static ParallelChunkLimit of(final int value) {
+        return new ParallelChunkLimit(value);
+    }
+
     @Override
     public void validate(final ValidationHandler handler) {
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Size.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Size.java
@@ -6,6 +6,10 @@ import org.osnormais.storage.api.domain.validation.handler.ValidationHandler;
 
 public record Size(long bytes) implements ValueObject {
 
+    public static Size of(final long bytes) {
+        return new Size(bytes);
+    }
+
     @Override
     public void validate(final ValidationHandler handler) {
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ThroughputLimit.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/ThroughputLimit.java
@@ -6,6 +6,10 @@ import org.osnormais.storage.api.domain.validation.handler.ValidationHandler;
 
 public record ThroughputLimit(long bytesPerSecond) implements ValueObject {
 
+    public static ThroughputLimit create(long bytesPerSecond) {
+        return new ThroughputLimit(bytesPerSecond);
+    }
+
     @Override
     public void validate(final ValidationHandler handler) {
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/TransferChannel.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/TransferChannel.java
@@ -10,6 +10,12 @@ public record TransferChannel(
         ThroughputLimit throughputLimit,
         ChunkSpecification chunkSpecification) implements ValueObject {
 
+    public static TransferChannel create(
+            final ThroughputLimit throughputLimit,
+            final ChunkSpecification chunkSpecification) {
+        return new TransferChannel(throughputLimit, chunkSpecification);
+    }
+
     @Override
     public void validate(final ValidationHandler handler) {
 

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
@@ -34,7 +34,7 @@ public class FileTest {
 
         final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
         final var expectedChecksumValue = "123";
-        final var expectedChecksum = new Checksum(expectedChecksumAlgorithm, expectedChecksumValue);
+        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
         final TransferChannel expectedUploadChannel = null;
         final TransferChannel expectedDownloadChannel = null;
@@ -67,7 +67,7 @@ public class FileTest {
 
         final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
         final var expectedChecksumValue = "123";
-        final var expectedChecksum = new Checksum(expectedChecksumAlgorithm, expectedChecksumValue);
+        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
         final TransferChannel expectedUploadChannel = null;
         final TransferChannel expectedDownloadChannel = null;
@@ -132,7 +132,7 @@ public class FileTest {
 
         final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
         final var expectedChecksumValue = "123";
-        final var expectedChecksum = new Checksum(expectedChecksumAlgorithm, expectedChecksumValue);
+        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
         final TransferChannel expectedUploadChannel = null;
         final TransferChannel expectedDownloadChannel = null;
@@ -165,7 +165,7 @@ public class FileTest {
 
         final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
         final var expectedChecksumValue = "123";
-        final var expectedChecksum = new Checksum(expectedChecksumAlgorithm, expectedChecksumValue);
+        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
         final var expectedThroughputLimit = ThroughputLimit.create(100L);
         final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L), ParallelChunkLimit.of(2));
@@ -205,7 +205,7 @@ public class FileTest {
 
         final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
         final var expectedChecksumValue = "123";
-        final var expectedChecksum = new Checksum(expectedChecksumAlgorithm, expectedChecksumValue);
+        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
         final TransferChannel expectedUploadChannel = null;
         final TransferChannel expectedDownloadChannel = null;
@@ -247,7 +247,7 @@ public class FileTest {
 
         final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
         final var expectedChecksumValue = "123";
-        final var expectedChecksum = new Checksum(expectedChecksumAlgorithm, expectedChecksumValue);
+        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
         final var expectedThroughputLimit = ThroughputLimit.create(100L);
         final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L), ParallelChunkLimit.of(2));

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
@@ -22,7 +22,7 @@ public class FileTest {
         final var expectedErrorMessage = "bytes must be greater than 0";
 
         final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = new FileId(expectedIdValue);
+        final var expectedFileId = FileId.of(expectedIdValue);
         final var expectedSize = new Size(-2L);
 
         final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
@@ -85,7 +85,7 @@ public class FileTest {
         final var expectedErrorMessage = "checksum cant be null";
 
         final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = new FileId(expectedIdValue);
+        final var expectedFileId = FileId.of(expectedIdValue);
         final var expectedSize = new Size(2L);
 
         final Checksum expectedChecksum = null;
@@ -120,7 +120,7 @@ public class FileTest {
         final var expectedHasErrors = false;
 
         final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = new FileId(expectedIdValue);
+        final var expectedFileId = FileId.of(expectedIdValue);
         final var expectedSize = new Size(2L);
 
         final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
@@ -1,14 +1,21 @@
 package org.osnormais.storage.api.domain.file;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.osnormais.storage.api.domain.exception.InvalidArgumentException;
+import org.osnormais.storage.api.domain.exception.UploadTransferChannelAlreadyOpennedException;
 import org.osnormais.storage.api.domain.exception.ValidationException;
 import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+import org.osnormais.storage.api.domain.file.valueobject.ChunkSpecification;
+import org.osnormais.storage.api.domain.file.valueobject.ParallelChunkLimit;
 import org.osnormais.storage.api.domain.file.valueobject.Size;
+import org.osnormais.storage.api.domain.file.valueobject.ThroughputLimit;
 import org.osnormais.storage.api.domain.file.valueobject.TransferChannel;
 import org.osnormais.storage.api.domain.validation.handler.Notification;
 
@@ -148,4 +155,131 @@ public class FileTest {
         assertEquals(expectedHasErrors, actualHasErrors);
 
     }
+
+    @Test
+    void givenValidTransferChannel_whenCallsOpenUploadChannel_thenShouldOpenChannel() {
+
+        final var expectedIdValue = UUID.randomUUID();
+        final var expectedFileId = FileId.of(expectedIdValue);
+        final var expectedSize = new Size(2L);
+
+        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+        final var expectedChecksumValue = "123";
+        final var expectedChecksum = new Checksum(expectedChecksumAlgorithm, expectedChecksumValue);
+
+        final var expectedThroughputLimit = ThroughputLimit.create(100L);
+        final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L), ParallelChunkLimit.of(2));
+
+        final var expectedUploadChannel = TransferChannel.create(
+                expectedThroughputLimit,
+                expectedChunkSpecification);
+
+        final TransferChannel expectedDownloadChannel = null;
+
+        final var expectedFile = File.with(
+                expectedFileId,
+                expectedSize,
+                expectedChecksum,
+                null,
+                expectedDownloadChannel);
+
+        assertTrue(expectedFile.getUploadChannel().isEmpty());
+
+        assertDoesNotThrow(() -> expectedFile.openUploadChannel(expectedUploadChannel));
+
+        assertTrue(expectedFile.getUploadChannel().isPresent());
+        assertEquals(expectedUploadChannel, expectedFile.getUploadChannel().get());
+
+    }
+
+    @Test
+    void givenNullTransferChannel_whenCallsOpenUploadChannel_thenShouldThrowsInvalidArgumentException() {
+
+        final var expectedExceptionMessage = "Invalid argument provided.";
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = "'transferChannel' should not be null";
+
+        final var expectedIdValue = UUID.randomUUID();
+        final var expectedFileId = FileId.of(expectedIdValue);
+        final var expectedSize = new Size(2L);
+
+        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+        final var expectedChecksumValue = "123";
+        final var expectedChecksum = new Checksum(expectedChecksumAlgorithm, expectedChecksumValue);
+
+        final TransferChannel expectedUploadChannel = null;
+        final TransferChannel expectedDownloadChannel = null;
+
+        final var expectedFile = File.with(
+                expectedFileId,
+                expectedSize,
+                expectedChecksum,
+                expectedUploadChannel,
+                expectedDownloadChannel);
+
+        assertTrue(expectedFile.getUploadChannel().isEmpty());
+
+        final var actualException = assertThrows(
+                InvalidArgumentException.class,
+                () -> expectedFile.openUploadChannel(expectedUploadChannel));
+
+        final var actualExceptionMessage = actualException.getMessage();
+        final var actualErrors = actualException.getErrors();
+        final var actualErrorsCount = actualException.getErrors().size();
+
+        assertEquals(actualExceptionMessage, expectedExceptionMessage);
+        assertEquals(expectedErrorsCount, actualErrors.size());
+        assertEquals(expectedErrorsCount, actualErrorsCount);
+        assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+
+    }
+
+    @Test
+    void givenValidTransferChannel_whenCallsOpenUploadChannelWithAlreadyOpenChannel_thenShouldOpenChannel() {
+
+        final var expectedExceptionMessage = "Upload transfer channel already open";
+        final var expectedErrorsCount = 1;
+        final var expectedErrorMessage = "Upload transfer channel already open, please close the current channel before opening a new one";
+
+        final var expectedIdValue = UUID.randomUUID();
+        final var expectedFileId = FileId.of(expectedIdValue);
+        final var expectedSize = new Size(2L);
+
+        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+        final var expectedChecksumValue = "123";
+        final var expectedChecksum = new Checksum(expectedChecksumAlgorithm, expectedChecksumValue);
+
+        final var expectedThroughputLimit = ThroughputLimit.create(100L);
+        final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L), ParallelChunkLimit.of(2));
+
+        final var expectedUploadChannel = TransferChannel.create(
+                expectedThroughputLimit,
+                expectedChunkSpecification);
+
+        final TransferChannel expectedDownloadChannel = null;
+
+        final var expectedFile = File.with(
+                expectedFileId,
+                expectedSize,
+                expectedChecksum,
+                expectedUploadChannel,
+                expectedDownloadChannel);
+
+        assertTrue(expectedFile.getUploadChannel().isPresent());
+
+        final var actualException = assertThrows(
+                UploadTransferChannelAlreadyOpennedException.class,
+                () -> expectedFile.openUploadChannel(expectedUploadChannel));
+
+        final var actualExceptionMessage = actualException.getMessage();
+        final var actualErrors = actualException.getErrors();
+        final var actualErrorsCount = actualException.getErrors().size();
+
+        assertEquals(actualExceptionMessage, expectedExceptionMessage);
+        assertEquals(expectedErrorsCount, actualErrors.size());
+        assertEquals(expectedErrorsCount, actualErrorsCount);
+        assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+
+    }
+
 }

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/ChecksumTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/ChecksumTest.java
@@ -20,7 +20,7 @@ public class ChecksumTest {
         final Algorithm expectedAlgorithm = null;
         final String expectedValue = null;
 
-        final var actualChecksum = assertDoesNotThrow(() -> new Checksum(expectedAlgorithm, expectedValue));
+        final var actualChecksum = assertDoesNotThrow(() -> Checksum.of(expectedAlgorithm, expectedValue));
 
         final var actualValidationHandler = Notification.create();
         actualChecksum.validate(actualValidationHandler);
@@ -42,7 +42,7 @@ public class ChecksumTest {
         final Algorithm expectedAlgorithm = Algorithm.MD5;
         final String expectedValue = "some-value";
 
-        final var actualChecksum = assertDoesNotThrow(() -> new Checksum(expectedAlgorithm, expectedValue));
+        final var actualChecksum = assertDoesNotThrow(() -> Checksum.of(expectedAlgorithm, expectedValue));
 
         final var actualValidationHandler = Notification.create();
         actualChecksum.validate(actualValidationHandler);

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecificationTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecificationTest.java
@@ -104,7 +104,7 @@ public class ChunkSpecificationTest {
     }
 
     @Test
-    void givenFileSizeBiggerThanChunkSize_whenCalculatingChunkBytesSize_thenReturnsChunkSize() {
+    void givenFileSizeBiggerThanChunkSize_whenCalculatingChunkBytesSize_thenReturnsEffectiveChunkSize() {
 
         final var expectedChunkBytesSize = Size.of(25L);
 
@@ -115,14 +115,14 @@ public class ChunkSpecificationTest {
 
         final var fileSize = new Size(100L);
 
-        final var actualChunkBytesSize = chunkSpecification.chunkBytesSize(fileSize);
+        final var actualChunkBytesSize = chunkSpecification.effectiveChunkSize(fileSize);
 
         assertEquals(expectedChunkBytesSize, actualChunkBytesSize);
 
     }
 
     @Test
-    void givenFileSizeSmallerThanChunkSize_whenCalculatingChunkBytesSize_thenReturnsFileSize() {
+    void givenFileSizeSmallerThanChunkSize_whenCalculatingEffectiveChunkSize_thenReturnsFileSize() {
 
         final var expectedChunkBytesSize = Size.of(100L);
 
@@ -133,7 +133,7 @@ public class ChunkSpecificationTest {
 
         final var fileSize = new Size(100L);
 
-        final var actualChunkBytesSize = chunkSpecification.chunkBytesSize(fileSize);
+        final var actualChunkBytesSize = chunkSpecification.effectiveChunkSize(fileSize);
 
         assertEquals(expectedChunkBytesSize, actualChunkBytesSize);
 

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecificationTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecificationTest.java
@@ -9,7 +9,7 @@ import org.osnormais.storage.api.domain.validation.handler.Notification;
 public class ChunkSpecificationTest {
 
     @Test
-    void givenSizeAndMaxParametersNull_whenValidate_thenShouldHandlerAppendTwoErrors() {
+    void givenSizeAndMaxParallelNull_whenValidate_thenShouldHandlerAppendTwoErrors() {
 
         final var expectedErrorCount = 2;
 

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecificationTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/ChunkSpecificationTest.java
@@ -1,10 +1,35 @@
 package org.osnormais.storage.api.domain.file.valueobject;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.osnormais.storage.api.domain.validation.handler.Notification;
 
 public class ChunkSpecificationTest {
+
+    @Test
+    void givenSizeAndMaxParametersNull_whenValidate_thenShouldHandlerAppendTwoErrors() {
+
+        final var expectedErrorCount = 2;
+
+        final var expetedErrorMessage1 = "Chunk 'size' should not be null";
+        final var expetedErrorMessage2 = "Chunk 'maxParallel' should not be null";
+
+        final Size expectedChunkSize = null;
+        final ParallelChunkLimit expectedParallelChunkLimit = null;
+
+        final var chunkSpecification = new ChunkSpecification(expectedChunkSize, expectedParallelChunkLimit);
+
+        final var handler = Notification.create();
+
+        assertDoesNotThrow(() -> chunkSpecification.validate(handler));
+
+        assertEquals(expectedErrorCount, handler.getErrors().size());
+        assertEquals(expetedErrorMessage1, handler.getErrors().get(0).message());
+        assertEquals(expetedErrorMessage2, handler.getErrors().get(1).message());
+
+    }
 
     @Test
     void givenFileSizeWithPartialChunk_whenCalculatingLastChunk_thenReturnsReminder() {
@@ -75,6 +100,42 @@ public class ChunkSpecificationTest {
         final var actualTotalChunks = chunkSpecification.totalChunks(fileSize);
 
         assertEquals(expectedTotalChunks, actualTotalChunks);
+
+    }
+
+    @Test
+    void givenFileSizeBiggerThanChunkSize_whenCalculatingChunkBytesSize_thenReturnsChunkSize() {
+
+        final var expectedChunkBytesSize = Size.of(25L);
+
+        final var actualChunkSize = new Size(25L);
+        final var actualParallelChunkLimit = new ParallelChunkLimit(1);
+
+        final var chunkSpecification = new ChunkSpecification(actualChunkSize, actualParallelChunkLimit);
+
+        final var fileSize = new Size(100L);
+
+        final var actualChunkBytesSize = chunkSpecification.chunkBytesSize(fileSize);
+
+        assertEquals(expectedChunkBytesSize, actualChunkBytesSize);
+
+    }
+
+    @Test
+    void givenFileSizeSmallerThanChunkSize_whenCalculatingChunkBytesSize_thenReturnsFileSize() {
+
+        final var expectedChunkBytesSize = Size.of(100L);
+
+        final var actualChunkSize = new Size(105L);
+        final var actualParallelChunkLimit = new ParallelChunkLimit(1);
+
+        final var chunkSpecification = new ChunkSpecification(actualChunkSize, actualParallelChunkLimit);
+
+        final var fileSize = new Size(100L);
+
+        final var actualChunkBytesSize = chunkSpecification.chunkBytesSize(fileSize);
+
+        assertEquals(expectedChunkBytesSize, actualChunkBytesSize);
 
     }
 

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/TransferChannelTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/TransferChannelTest.java
@@ -1,0 +1,34 @@
+package org.osnormais.storage.api.domain.file.valueobject;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.osnormais.storage.api.domain.validation.handler.Notification;
+
+public class TransferChannelTest {
+
+    @Test
+    void givenThroughputLimitAndChunkSpecificationNull_whenValidate_thenShouldHandlerAppendTwoErrors() {
+
+        final var expectedErrorCount = 2;
+
+        final var expetedErrorMessage1 = "'throughputLimit' should not be null";
+        final var expetedErrorMessage2 = "'chunkSpecification' should not be null";
+
+        final ThroughputLimit expectedThroughputLimit = null;
+        final ChunkSpecification expectedChunkSpecification = null;
+
+        final var transferChannel = new TransferChannel(expectedThroughputLimit, expectedChunkSpecification);
+
+        final var handler = Notification.create();
+
+        assertDoesNotThrow(() -> transferChannel.validate(handler));
+
+        assertEquals(expectedErrorCount, handler.getErrors().size());
+        assertEquals(expetedErrorMessage1, handler.getErrors().get(0).message());
+        assertEquals(expetedErrorMessage2, handler.getErrors().get(1).message());
+
+    }
+
+}


### PR DESCRIPTION

## UploadTransferChannel
- Adiciona o caso de uso para criação de um Canal de Transferência de Upload. 

## Testes
- Cobre com testes unitários:
    - Caso de uso
    - ValueObjects gerados
    - Entidade File

## Testes - Evidências 

<img width="583" height="124" alt="image" src="https://github.com/user-attachments/assets/4032e7f9-4be3-4970-8528-d1e1e0c3f59a" />

<img width="744" height="165" alt="image" src="https://github.com/user-attachments/assets/6c1be436-f593-4fb3-b136-bfc7812d4812" />

<img width="779" height="333" alt="image" src="https://github.com/user-attachments/assets/c4afb595-fc5a-4cc1-8f2e-4dffcc305d09" />

PS: 
- getters que ainda não foram utilizados não foram testados
- create será testado quando for ser utilizado pelo caso de uso de criação

## Próximos passos
- Caso de uso para criação de 'File'
- Recebimento de Chunk's







