### PR TITLE
Create File (ApplicationLayer)

### DIFF
--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/create/CreateFileInput.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/create/CreateFileInput.java
@@ -1,0 +1,13 @@
+package org.osnormais.storage.api.application.usecase.file.create;
+
+import java.util.UUID;
+
+import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+
+public record CreateFileInput(
+        UUID id,
+        Long sizeInBytes,
+        String checksumValue,
+        Checksum.Algorithm checksumAlgorithm) {
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/create/CreateFileOutput.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/create/CreateFileOutput.java
@@ -1,0 +1,13 @@
+package org.osnormais.storage.api.application.usecase.file.create;
+
+import java.util.UUID;
+
+import org.osnormais.storage.api.domain.file.File;
+
+public record CreateFileOutput(UUID id) {
+
+    public static CreateFileOutput of(final File file) {
+        return new CreateFileOutput(file.getId().getValue());
+    }
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/create/CreateFileUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/create/CreateFileUseCase.java
@@ -1,0 +1,7 @@
+package org.osnormais.storage.api.application.usecase.file.create;
+
+import org.osnormais.storage.api.application.usecase.UseCase;
+
+public abstract class CreateFileUseCase extends UseCase<CreateFileInput, CreateFileOutput> {
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/create/DefaultCreateFileUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/create/DefaultCreateFileUseCase.java
@@ -1,0 +1,42 @@
+package org.osnormais.storage.api.application.usecase.file.create;
+
+import static java.util.Objects.requireNonNull;
+
+import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
+import org.osnormais.storage.api.domain.exception.ValidationException;
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+import org.osnormais.storage.api.domain.file.valueobject.Size;
+import org.osnormais.storage.api.domain.validation.handler.Notification;
+import org.osnormais.storage.api.domain.validation.handler.ValidationHandler;
+
+public class DefaultCreateFileUseCase extends CreateFileUseCase {
+
+    private final FileCommandGateway fileCommandGateway;
+
+    public DefaultCreateFileUseCase(final FileCommandGateway fileCommandGateway) {
+        this.fileCommandGateway = requireNonNull(fileCommandGateway);
+    }
+
+    @Override
+    public CreateFileOutput execute(final CreateFileInput input) {
+
+        final FileId fileId = FileId.of(input.id());
+        final Size fileSize = Size.of(input.sizeInBytes());
+        final Checksum fileChecksum = Checksum.of(input.checksumAlgorithm(), input.checksumValue());
+
+        final ValidationHandler handler = Notification.create();
+
+        final File file = handler.validate(() -> File.create(fileId, fileSize, fileChecksum));
+
+        if (handler.hasErrors())
+            throw ValidationException.with("Failed to create File", handler);
+
+        fileCommandGateway.create(file);
+
+        return CreateFileOutput.of(file);
+
+    }
+
+}

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/create/DefaultCreateFileUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/create/DefaultCreateFileUseCaseTest.java
@@ -1,0 +1,100 @@
+package org.osnormais.storage.api.application.usecase.file.create;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
+import org.osnormais.storage.api.domain.exception.ValidationException;
+import org.osnormais.storage.api.domain.file.FileId;
+import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+import org.osnormais.storage.api.domain.file.valueobject.Size;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultCreateFileUseCaseTest {
+
+    @InjectMocks
+    DefaultCreateFileUseCase useCase;
+
+    @Mock
+    FileCommandGateway fileCommandGateway;
+
+    @Test
+    void givenAnValidInput_whenCallsExecute_thenShouldCreateFile() {
+
+        final var expectedFileIdValue = UUID.randomUUID();
+        final var expectedFileSizeInBytesValue = 1024L;
+        final var expectedFileChecksumValue = "checksumValue";
+        final var expectedFileChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+
+        final var expectedFileId = FileId.of(expectedFileIdValue);
+        final var expectedFileSize = Size.of(expectedFileSizeInBytesValue);
+        final var expectedFileChecksum = Checksum.of(expectedFileChecksumAlgorithm, expectedFileChecksumValue);
+
+        when(fileCommandGateway
+                .create(argThat(file -> {
+
+                    assertEquals(expectedFileId, file.getId());
+                    assertEquals(expectedFileSize, file.getSize());
+                    assertEquals(expectedFileChecksum, file.getChecksum());
+                    assertTrue(file.getUploadChannel().isEmpty());
+                    assertTrue(file.getDownloadChannel().isEmpty());
+
+                    return true;
+
+                }))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        final var input = new CreateFileInput(
+                expectedFileIdValue,
+                expectedFileSizeInBytesValue,
+                expectedFileChecksumValue,
+                expectedFileChecksumAlgorithm);
+
+        final var actualOutput = assertDoesNotThrow(() -> useCase.execute(input));
+
+        assertEquals(expectedFileIdValue, actualOutput.id());
+
+        verify(fileCommandGateway, times(1)).create(any());
+
+    }
+
+    @Test
+    void givenAnInvalidSizeInBytesInput_whenCallsExecute_thenShouldThrowsValidationException() {
+
+        final var expectedExceptionMessage = "Failed to create File";
+        final var expectedErrorMessage = "bytes must be greater than 0";
+
+        final var expectedFileIdValue = UUID.randomUUID();
+        final var expectedFileSizeInBytesValue = -1024L;
+        final var expectedFileChecksumValue = "checksumValue";
+        final var expectedFileChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+
+        final var input = new CreateFileInput(
+                expectedFileIdValue,
+                expectedFileSizeInBytesValue,
+                expectedFileChecksumValue,
+                expectedFileChecksumAlgorithm);
+
+        final var actualException = assertThrows(ValidationException.class, () -> useCase.execute(input));
+
+        assertEquals(expectedExceptionMessage, actualException.getMessage());
+        assertEquals(expectedErrorMessage, actualException.getErrors().get(0).message());
+
+        verify(fileCommandGateway, times(0)).create(any());
+
+    }
+
+}

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
@@ -84,8 +84,8 @@ public class File extends AggregateRoot<FileId> {
                 id,
                 size,
                 checksum,
-                null,
-                null);
+                Optional.empty(),
+                Optional.empty());
     }
 
     public File openUploadChannel(final TransferChannel transferChannel) {

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -279,6 +280,55 @@ public class FileTest {
         assertEquals(expectedErrorsCount, actualErrors.size());
         assertEquals(expectedErrorsCount, actualErrorsCount);
         assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+
+    }
+
+    @Test
+    void givenValidArguments_whenCallsCreate_thenShouldCreateFile() {
+
+        final var expectedIdValue = UUID.randomUUID();
+        final var expectedFileId = FileId.of(expectedIdValue);
+        final var expectedSize = new Size(2L);
+
+        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+        final var expectedChecksumValue = "123";
+        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+        final var expectedUploadChannel = Optional.<TransferChannel>empty();
+        final var expectedDownloadChannel = Optional.<TransferChannel>empty();
+
+        final var actualFile = assertDoesNotThrow(() -> File.create(expectedFileId, expectedSize, expectedChecksum));
+
+        assertEquals(expectedIdValue, actualFile.getId().getValue());
+        assertEquals(expectedFileId, actualFile.getId());
+        assertEquals(expectedSize, actualFile.getSize());
+        assertEquals(expectedChecksum, actualFile.getChecksum());
+        assertEquals(expectedUploadChannel, actualFile.getUploadChannel());
+        assertEquals(expectedDownloadChannel, actualFile.getDownloadChannel());
+
+    }
+
+    @Test
+    void givenNullArguments_whenCallsCreate_thenShouldThrowsValidationException() {
+
+        final var expectedExceptionMessage = "'File' validation failed";
+
+        final var expectedErrorCount = 2;
+        final var expectedErrorMessage0 = "size cant be null";
+        final var expectedErrorMessage1 = "checksum cant be null";
+
+        final var expectedIdValue = UUID.randomUUID();
+        final var expectedFileId = FileId.of(expectedIdValue);
+        final Size expectedSize = null;
+        final Checksum expectedChecksum = null;
+
+        final var actualException = assertThrows(ValidationException.class,
+                () -> File.create(expectedFileId, expectedSize, expectedChecksum));
+
+        assertEquals(actualException.getMessage(), expectedExceptionMessage);
+        assertEquals(actualException.getErrors().size(), expectedErrorCount);
+        assertEquals(actualException.getErrors().get(0).message(), expectedErrorMessage0);
+        assertEquals(actualException.getErrors().get(1).message(), expectedErrorMessage1);
 
     }
 


### PR DESCRIPTION
# Create File
Este pull request implementa na camada de aplicação (application) o caso de uso para criação de um arquivo (file).

## Ajustes adicionais
- Corrige Factory Method File.create, onde ao passar "null" nos canais de transferência ocorria um null pointer.

## Testes Unitários
- Caso de uso (CreateFileUseCase)
- Factory Method File.create

## O que esse PR não faz.
- Implementa a camada de infrastrutura.
- Fluxo completo de upload
