### PR TITLE
feat: montar arquivo final após conclusão do upload

### DIFF
--- a/application/src/main/java/org/osnormais/storage/api/application/port/FileFinalizer.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/port/FileFinalizer.java
@@ -1,0 +1,11 @@
+package org.osnormais.storage.api.application.port;
+
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+
+@FunctionalInterface
+public interface FileFinalizer {
+
+    Checksum finalize(File file);
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/DefaultFinalizeFileUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/DefaultFinalizeFileUseCase.java
@@ -6,24 +6,27 @@ import org.osnormais.storage.api.application.exception.NotFoundException;
 import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
 import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
 import org.osnormais.storage.api.application.port.FileFinalizer;
+import org.osnormais.storage.api.domain.event.DomainEventDispatcher;
 import org.osnormais.storage.api.domain.file.File;
 import org.osnormais.storage.api.domain.file.FileId;
 import org.osnormais.storage.api.domain.file.valueobject.Checksum;
-import org.osnormais.storage.api.domain.file.valueobject.Publication;
 
 public class DefaultFinalizeFileUseCase extends FinalizeFileUseCase {
 
     private final FileQueryGateway fileQueryGateway;
     private final FileCommandGateway fileCommandGateway;
     private final FileFinalizer fileFinalizer;
+    private final DomainEventDispatcher eventDispatcher;
 
     public DefaultFinalizeFileUseCase(
             final FileQueryGateway fileQueryGateway,
             final FileCommandGateway fileCommandGateway,
-            final FileFinalizer fileFinalizer) {
+            final FileFinalizer fileFinalizer,
+            final DomainEventDispatcher eventDispatcher) {
         this.fileQueryGateway = requireNonNull(fileQueryGateway);
         this.fileCommandGateway = requireNonNull(fileCommandGateway);
         this.fileFinalizer = requireNonNull(fileFinalizer);
+        this.eventDispatcher = requireNonNull(eventDispatcher);
     }
 
     @Override
@@ -33,21 +36,15 @@ public class DefaultFinalizeFileUseCase extends FinalizeFileUseCase {
 
         final File file = fileQueryGateway
                 .findById(fileId)
-                .orElseThrow(() -> NotFoundException.create(File.class, fileId));
+                .orElseThrow(() -> NotFoundException.create(File.class, fileId))
+                .validateCanBeFinalized();
 
         if (file.isPublished())
             return;
 
         final Checksum checksum = fileFinalizer.finalize(file);
-        if (file.getChecksum().equals(checksum))
-            file.completePublication();
-        else
-            file.failPublication(
-                    Publication.Error.of(
-                            "File integrity compromised during finalization. Expected checksum: %s, actual checksum: %s"
-                                    .formatted(file.getChecksum(), checksum)));
-
-        fileCommandGateway.update(file);
+        file.finalizePublication(checksum);
+        eventDispatcher.notify(fileCommandGateway.update(file));
 
     }
 

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/DefaultFinalizeFileUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/DefaultFinalizeFileUseCase.java
@@ -2,7 +2,6 @@ package org.osnormais.storage.api.application.usecase.file.finalize;
 
 import static java.util.Objects.requireNonNull;
 
-import org.osnormais.storage.api.application.exception.ChunkIntegrityViolationException;
 import org.osnormais.storage.api.application.exception.NotFoundException;
 import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
 import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
@@ -10,6 +9,7 @@ import org.osnormais.storage.api.application.port.FileFinalizer;
 import org.osnormais.storage.api.domain.file.File;
 import org.osnormais.storage.api.domain.file.FileId;
 import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+import org.osnormais.storage.api.domain.file.valueobject.Publication;
 
 public class DefaultFinalizeFileUseCase extends FinalizeFileUseCase {
 
@@ -33,12 +33,19 @@ public class DefaultFinalizeFileUseCase extends FinalizeFileUseCase {
 
         final File file = fileQueryGateway
                 .findById(fileId)
-                .orElseThrow(() -> NotFoundException.create(File.class, fileId))
-                .publish();
+                .orElseThrow(() -> NotFoundException.create(File.class, fileId));
+
+        if (file.isPublished())
+            return;
 
         final Checksum checksum = fileFinalizer.finalize(file);
-        if (!file.getChecksum().equals(checksum))
-            throw ChunkIntegrityViolationException.create(file.getChecksum(), checksum);
+        if (file.getChecksum().equals(checksum))
+            file.completePublication();
+        else
+            file.failPublication(
+                    Publication.Error.of(
+                            "File integrity compromised during finalization. Expected checksum: %s, actual checksum: %s"
+                                    .formatted(file.getChecksum(), checksum)));
 
         fileCommandGateway.update(file);
 

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/DefaultFinalizeFileUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/DefaultFinalizeFileUseCase.java
@@ -1,0 +1,47 @@
+package org.osnormais.storage.api.application.usecase.file.finalize;
+
+import static java.util.Objects.requireNonNull;
+
+import org.osnormais.storage.api.application.exception.ChunkIntegrityViolationException;
+import org.osnormais.storage.api.application.exception.NotFoundException;
+import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
+import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
+import org.osnormais.storage.api.application.port.FileFinalizer;
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+
+public class DefaultFinalizeFileUseCase extends FinalizeFileUseCase {
+
+    private final FileQueryGateway fileQueryGateway;
+    private final FileCommandGateway fileCommandGateway;
+    private final FileFinalizer fileFinalizer;
+
+    public DefaultFinalizeFileUseCase(
+            final FileQueryGateway fileQueryGateway,
+            final FileCommandGateway fileCommandGateway,
+            final FileFinalizer fileFinalizer) {
+        this.fileQueryGateway = requireNonNull(fileQueryGateway);
+        this.fileCommandGateway = requireNonNull(fileCommandGateway);
+        this.fileFinalizer = requireNonNull(fileFinalizer);
+    }
+
+    @Override
+    public void execute(final FinalizeFileInput input) {
+
+        final FileId fileId = FileId.of(input.fileId());
+
+        final File file = fileQueryGateway
+                .findById(fileId)
+                .orElseThrow(() -> NotFoundException.create(File.class, fileId))
+                .publish();
+
+        final Checksum checksum = fileFinalizer.finalize(file);
+        if (!file.getChecksum().equals(checksum))
+            throw ChunkIntegrityViolationException.create(file.getChecksum(), checksum);
+
+        fileCommandGateway.update(file);
+
+    }
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/FinalizeFileInput.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/FinalizeFileInput.java
@@ -1,0 +1,7 @@
+package org.osnormais.storage.api.application.usecase.file.finalize;
+
+import java.util.UUID;
+
+public record FinalizeFileInput(UUID fileId) {
+
+}

--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/FinalizeFileUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/finalize/FinalizeFileUseCase.java
@@ -1,0 +1,7 @@
+package org.osnormais.storage.api.application.usecase.file.finalize;
+
+import org.osnormais.storage.api.application.usecase.UnitUseCase;
+
+public abstract class FinalizeFileUseCase extends UnitUseCase<FinalizeFileInput> {
+
+}

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/chunk/upload/DefaultUploadFileChunkUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/chunk/upload/DefaultUploadFileChunkUseCaseTest.java
@@ -87,7 +87,7 @@ public class DefaultUploadFileChunkUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedFileChecksum,
-                false,
+                null,
                 expectedUploadTransferChannel,
                 null,
                 null);
@@ -190,7 +190,7 @@ public class DefaultUploadFileChunkUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedFileChecksum,
-                false,
+                null,
                 expectedUploadTransferChannel,
                 null,
                 null);
@@ -257,7 +257,7 @@ public class DefaultUploadFileChunkUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedFileChecksum,
-                false,
+                null,
                 expectedUploadTransferChannel,
                 null,
                 null);
@@ -385,7 +385,7 @@ public class DefaultUploadFileChunkUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedFileChecksum,
-                false,
+                null,
                 expectedUploadTransferChannel,
                 null,
                 null);

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/chunk/upload/DefaultUploadFileChunkUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/chunk/upload/DefaultUploadFileChunkUseCaseTest.java
@@ -87,6 +87,7 @@ public class DefaultUploadFileChunkUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedFileChecksum,
+                false,
                 expectedUploadTransferChannel,
                 null,
                 null);
@@ -189,6 +190,7 @@ public class DefaultUploadFileChunkUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedFileChecksum,
+                false,
                 expectedUploadTransferChannel,
                 null,
                 null);
@@ -255,6 +257,7 @@ public class DefaultUploadFileChunkUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedFileChecksum,
+                false,
                 expectedUploadTransferChannel,
                 null,
                 null);
@@ -382,6 +385,7 @@ public class DefaultUploadFileChunkUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedFileChecksum,
+                false,
                 expectedUploadTransferChannel,
                 null,
                 null);

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/finalize/DefaultFinalizeFileUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/finalize/DefaultFinalizeFileUseCaseTest.java
@@ -1,0 +1,178 @@
+package org.osnormais.storage.api.application.usecase.file.finalize;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.osnormais.storage.api.application.exception.NotFoundException;
+import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
+import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
+import org.osnormais.storage.api.application.port.FileFinalizer;
+import org.osnormais.storage.api.domain.event.DomainEventDispatcher;
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+import org.osnormais.storage.api.domain.file.event.FilePublishedEvent;
+import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+import org.osnormais.storage.api.domain.file.valueobject.Checksum.Algorithm;
+import org.osnormais.storage.api.domain.file.valueobject.Publication;
+import org.osnormais.storage.api.domain.file.valueobject.Size;
+import org.osnormais.storage.api.domain.file.valueobject.TransferChannel;
+
+@ExtendWith(MockitoExtension.class)
+public class DefaultFinalizeFileUseCaseTest {
+
+    @InjectMocks
+    DefaultFinalizeFileUseCase useCase;
+
+    @Mock
+    FileQueryGateway fileQueryGateway;
+
+    @Mock
+    FileCommandGateway fileCommandGateway;
+
+    @Mock
+    FileFinalizer fileFinalizer;
+
+    @Mock
+    DomainEventDispatcher eventDispatcher;
+
+    @Test
+    void givenAnValidInput_whenCallsExecute_thenShouldFinalizeFileAndNotifyEvent() {
+
+        final var expectedFileIdValue = UUID.randomUUID();
+        final var expectedFileId = FileId.of(expectedFileIdValue);
+        final var expectedFileChecksum = Checksum.of(Algorithm.MD5, "checksumMD5");
+
+        final var expectedEventType = FilePublishedEvent.class;
+        final var expectedEventKey = FilePublishedEvent.eventKey();
+
+        final TransferChannel uploadTransferChannel = null;
+
+        final var expectedFile = File.with(
+                expectedFileId,
+                Size.of(2048L),
+                expectedFileChecksum,
+                null,
+                uploadTransferChannel,
+                null,
+                null);
+
+        when(fileQueryGateway.findById(expectedFileId))
+                .thenReturn(Optional.of(expectedFile));
+
+        when(fileCommandGateway.update(expectedFile))
+                .thenReturn(expectedFile);
+
+        when(fileFinalizer.finalize(expectedFile))
+                .thenReturn(expectedFileChecksum);
+
+        doNothing()
+                .when(eventDispatcher)
+                .notify(expectedFile);
+
+        final var input = new FinalizeFileInput(expectedFileIdValue);
+
+        assertDoesNotThrow(() -> useCase.execute(input));
+
+        verify(fileQueryGateway, times(1)).findById(expectedFileId);
+        verify(fileQueryGateway, times(1)).findById(any());
+        verify(fileCommandGateway, times(1)).update(expectedFile);
+        verify(fileCommandGateway, times(1)).update(any());
+
+        ArgumentCaptor<File> captor = ArgumentCaptor.forClass(File.class);
+        verify(eventDispatcher, times(1)).notify(captor.capture());
+        verify(eventDispatcher, times(1)).notify(any(File.class));
+
+        final var eventDispatcherArg = captor.getValue();
+        final var firstEvent = eventDispatcherArg.nextEvent();
+
+        assertEquals(expectedFileId, eventDispatcherArg.getId());
+        assertTrue(firstEvent.isPresent());
+        assertEquals(expectedEventType, firstEvent.get().getClass());
+        assertEquals(expectedEventKey, firstEvent.get().key());
+        assertEquals(expectedFileId, firstEvent.get().getIdentifier());
+        assertTrue(eventDispatcherArg.nextEvent().isEmpty());
+
+    }
+
+    @Test
+    void givenANonExistentFileId_whenCallsExecuteWithPublishedFile_thenShouldThrowsNotFoundException() {
+
+        final var expectedFileIdValue = UUID.randomUUID();
+        final var expectedFileId = FileId.of(expectedFileIdValue);
+
+        final var expectedExcpetionMessage = "[%s] not found".formatted(File.class.getSimpleName());
+        final var expectedErrorsCount = 1;
+        final var expectedExceptionErrorMessage0 = "[%s] with id [%s] not found"
+                .formatted(
+                        File.class.getSimpleName(),
+                        expectedFileIdValue.toString());
+
+        when(fileQueryGateway.findById(expectedFileId))
+                .thenReturn(Optional.empty());
+
+        final var input = new FinalizeFileInput(expectedFileIdValue);
+
+        final var actualException = assertThrows(NotFoundException.class, () -> useCase.execute(input));
+
+        assertEquals(expectedExcpetionMessage, actualException.getMessage());
+        assertEquals(expectedErrorsCount, actualException.getErrors().size());
+        assertEquals(expectedExceptionErrorMessage0, actualException.getErrors().get(0).message());
+
+        verify(fileQueryGateway, times(1)).findById(expectedFileId);
+        verify(fileQueryGateway, times(1)).findById(any());
+        verify(fileCommandGateway, times(0)).update(any());
+        verify(fileFinalizer, times(0)).finalize(any());
+        verify(eventDispatcher, times(0)).notify(any(File.class));
+
+    }
+
+    @Test
+    void givenAnValidInput_whenCallsExecuteWithPublishedFile_thenShouldNothing() {
+
+        final var expectedFileIdValue = UUID.randomUUID();
+        final var expectedFileId = FileId.of(expectedFileIdValue);
+        final var expectedFileChecksum = Checksum.of(Algorithm.MD5, "checksumMD5");
+
+        final TransferChannel uploadTransferChannel = null;
+
+        final var expectedFile = File.with(
+                expectedFileId,
+                Size.of(2048L),
+                expectedFileChecksum,
+                Publication.ok(),
+                uploadTransferChannel,
+                null,
+                null);
+
+        when(fileQueryGateway.findById(expectedFileId))
+                .thenReturn(Optional.of(expectedFile));
+
+        final var input = new FinalizeFileInput(expectedFileIdValue);
+
+        assertDoesNotThrow(() -> useCase.execute(input));
+
+        verify(fileQueryGateway, times(1)).findById(expectedFileId);
+        verify(fileQueryGateway, times(1)).findById(any());
+        verify(fileCommandGateway, times(0)).update(any());
+        verify(fileFinalizer, times(0)).finalize(any());
+        verify(eventDispatcher, times(0)).notify(any(File.class));
+
+    }
+
+}

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/complete/DefaultCompleteFileUploadTransferChannelUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/complete/DefaultCompleteFileUploadTransferChannelUseCaseTest.java
@@ -78,6 +78,7 @@ public class DefaultCompleteFileUploadTransferChannelUseCaseTest {
                 expectedFileId,
                 Size.of(2048L),
                 Checksum.of(Algorithm.MD5, "checksumMD5"),
+                false,
                 uploadTransferChannel,
                 null,
                 null);

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/complete/DefaultCompleteFileUploadTransferChannelUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/complete/DefaultCompleteFileUploadTransferChannelUseCaseTest.java
@@ -78,7 +78,7 @@ public class DefaultCompleteFileUploadTransferChannelUseCaseTest {
                 expectedFileId,
                 Size.of(2048L),
                 Checksum.of(Algorithm.MD5, "checksumMD5"),
-                false,
+                null,
                 uploadTransferChannel,
                 null,
                 null);

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
@@ -73,7 +73,7 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedCheckcum,
-                false,
+                null,
                 null,
                 null,
                 null);
@@ -198,7 +198,7 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedCheckcum,
-                false,
+                null,
                 transferChannel,
                 null,
                 null);

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
@@ -73,6 +73,7 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedCheckcum,
+                false,
                 null,
                 null,
                 null);
@@ -197,6 +198,7 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
                 expectedFileId,
                 expectedFileSize,
                 expectedCheckcum,
+                false,
                 transferChannel,
                 null,
                 null);

--- a/domain/src/main/java/org/osnormais/storage/api/domain/event/DomainEventDispatcher.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/event/DomainEventDispatcher.java
@@ -6,7 +6,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.osnormais.storage.api.domain.Identifier;
 
-public final class DomainEventDispatcher {
+public class DomainEventDispatcher {
 
     private final ConcurrentHashMap<String, List<DomainEventHandler<?>>> handlers = new ConcurrentHashMap<>();
 

--- a/domain/src/main/java/org/osnormais/storage/api/domain/exception/FileAlreadyPublishedException.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/exception/FileAlreadyPublishedException.java
@@ -1,0 +1,22 @@
+package org.osnormais.storage.api.domain.exception;
+
+import java.util.List;
+
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+
+public class FileAlreadyPublishedException extends SilentDomainException {
+
+    private static final String MESSAGE = "File [%s], already published";
+
+    private FileAlreadyPublishedException(final FileId fileId) {
+        super(
+                MESSAGE.formatted(fileId.getStringValue()),
+                List.of());
+    }
+
+    public static FileAlreadyPublishedException create(final File file) {
+        return new FileAlreadyPublishedException(file.getId());
+    }
+
+}

--- a/domain/src/main/java/org/osnormais/storage/api/domain/exception/FileUploadInProgressException.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/exception/FileUploadInProgressException.java
@@ -1,0 +1,23 @@
+package org.osnormais.storage.api.domain.exception;
+
+import java.util.List;
+
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+
+public class FileUploadInProgressException extends SilentDomainException {
+
+    private static final String MESSAGE = "Upload transfer channel openned for this file [%s], upload in progress";
+    private static final String ERROR = MESSAGE + ", please close the current channel before publishing the file";
+
+    private FileUploadInProgressException(final FileId fileId) {
+        super(
+                MESSAGE.formatted(fileId.getStringValue()),
+                List.of(DomainException.Error.with(ERROR.formatted(fileId.getStringValue()))));
+    }
+
+    public static FileUploadInProgressException create(final File file) {
+        return new FileUploadInProgressException(file.getId());
+    }
+
+}

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
@@ -148,40 +148,58 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
 
     }
 
-    public File completePublication() {
-
-        if (isPublished())
-            return this;
-
-        if (this.uploadChannel.isPresent())
-            throw FileUploadInProgressException.create(this);
-
-        this.publication = Optional.of(Publication.ok());
-        events.add(FilePublishedEvent.create(this));
-
-        return this;
-
-    }
-
-    public File failPublication(final Publication.Error error) {
-
-        if (isPublished())
-            throw FileAlreadyPublishedException.create(this);
-
-        if (this.uploadChannel.isPresent())
-            throw FileUploadInProgressException.create(this);
-
-        this.publication = Optional.of(Publication.error(error));
-        events.add(FilePublishFailedEvent.create(this));
-
-        return this;
-    }
-
     public Boolean isPublished() {
         return this.publication
                 .map(Publication::status)
                 .filter(status -> Publication.Status.OK.equals(status))
                 .isPresent();
+    }
+
+    public File validateCanBeFinalized() {
+
+        if (this.uploadChannel.isPresent())
+            throw FileUploadInProgressException.create(this);
+
+        return this;
+    }
+
+    public File finalizePublication(final Checksum checksum) {
+
+        if (isNull(checksum))
+            throw InvalidArgumentException.with(DomainException.Error.with("'checksum' should not be null"));
+
+        validateCanBeFinalized();
+
+        if (this.checksum.equals(checksum))
+            completePublication();
+        else
+            failPublication(
+                    Publication.Error.of(
+                            "File integrity compromised during finalization. Expected checksum: %s, actual checksum: %s"
+                                    .formatted(this.checksum, checksum)));
+
+        return this;
+
+    }
+
+    private void completePublication() {
+
+        if (isPublished())
+            return;
+
+        this.publication = Optional.of(Publication.ok());
+        events.add(FilePublishedEvent.create(this));
+
+    }
+
+    private void failPublication(final Publication.Error error) {
+
+        if (isPublished())
+            throw FileAlreadyPublishedException.create(this);
+
+        this.publication = Optional.of(Publication.error(error));
+        events.add(FilePublishFailedEvent.create(this));
+
     }
 
     private void selfValidate() {

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
@@ -11,9 +11,11 @@ import org.osnormais.storage.api.domain.AggregateRoot;
 import org.osnormais.storage.api.domain.event.DomainEvent;
 import org.osnormais.storage.api.domain.event.DomainEventSource;
 import org.osnormais.storage.api.domain.exception.DomainException;
+import org.osnormais.storage.api.domain.exception.FileUploadInProgressException;
 import org.osnormais.storage.api.domain.exception.InvalidArgumentException;
 import org.osnormais.storage.api.domain.exception.UploadTransferChannelAlreadyOpennedException;
 import org.osnormais.storage.api.domain.exception.ValidationException;
+import org.osnormais.storage.api.domain.file.event.FilePublishedEvent;
 import org.osnormais.storage.api.domain.file.event.FileUploadTransferChannelCompletedEvent;
 import org.osnormais.storage.api.domain.file.valueobject.Checksum;
 import org.osnormais.storage.api.domain.file.valueobject.Size;
@@ -26,6 +28,7 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
 
     private final Size size;
     private final Checksum checksum;
+    private Boolean published;
 
     private Optional<TransferChannel> uploadChannel;
     private Optional<TransferChannel> downloadChannel;
@@ -36,12 +39,14 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
             final FileId id,
             final Size size,
             final Checksum checksum,
+            final Boolean published,
             final Optional<TransferChannel> uploadChannel,
             final Optional<TransferChannel> downloadChannel,
             final Queue<DomainEvent<?>> events) {
         super(id);
         this.size = size;
         this.checksum = checksum;
+        this.published = published;
         this.uploadChannel = uploadChannel;
         this.downloadChannel = downloadChannel;
 
@@ -54,6 +59,7 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
             final FileId id,
             final Size size,
             final Checksum checksum,
+            final Boolean published,
             final TransferChannel uploadChannel,
             final TransferChannel downloadChannel,
             final Queue<DomainEvent<?>> events) {
@@ -61,6 +67,7 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
                 id,
                 size,
                 checksum,
+                published,
                 Optional.ofNullable(uploadChannel),
                 Optional.ofNullable(downloadChannel),
                 events);
@@ -102,6 +109,7 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
                 id,
                 size,
                 checksum,
+                false,
                 Optional.empty(),
                 Optional.empty(),
                 new LinkedList<>());
@@ -133,6 +141,21 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
 
     }
 
+    public File publish() {
+
+        if (published)
+            return this;
+
+        if (this.uploadChannel.isPresent())
+            throw FileUploadInProgressException.create(this);
+
+        this.published = true;
+        events.add(FilePublishedEvent.create(this));
+
+        return this;
+
+    }
+
     private void selfValidate() {
         final Notification notification = Notification.create();
         validate(notification);
@@ -146,6 +169,10 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
 
     public Checksum getChecksum() {
         return checksum;
+    }
+
+    public Boolean getPublished() {
+        return published;
     }
 
     public Optional<TransferChannel> getUploadChannel() {

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/File.java
@@ -11,13 +11,16 @@ import org.osnormais.storage.api.domain.AggregateRoot;
 import org.osnormais.storage.api.domain.event.DomainEvent;
 import org.osnormais.storage.api.domain.event.DomainEventSource;
 import org.osnormais.storage.api.domain.exception.DomainException;
+import org.osnormais.storage.api.domain.exception.FileAlreadyPublishedException;
 import org.osnormais.storage.api.domain.exception.FileUploadInProgressException;
 import org.osnormais.storage.api.domain.exception.InvalidArgumentException;
 import org.osnormais.storage.api.domain.exception.UploadTransferChannelAlreadyOpennedException;
 import org.osnormais.storage.api.domain.exception.ValidationException;
+import org.osnormais.storage.api.domain.file.event.FilePublishFailedEvent;
 import org.osnormais.storage.api.domain.file.event.FilePublishedEvent;
 import org.osnormais.storage.api.domain.file.event.FileUploadTransferChannelCompletedEvent;
 import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+import org.osnormais.storage.api.domain.file.valueobject.Publication;
 import org.osnormais.storage.api.domain.file.valueobject.Size;
 import org.osnormais.storage.api.domain.file.valueobject.TransferChannel;
 import org.osnormais.storage.api.domain.validation.ValidationError;
@@ -28,7 +31,7 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
 
     private final Size size;
     private final Checksum checksum;
-    private Boolean published;
+    private Optional<Publication> publication;
 
     private Optional<TransferChannel> uploadChannel;
     private Optional<TransferChannel> downloadChannel;
@@ -39,14 +42,14 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
             final FileId id,
             final Size size,
             final Checksum checksum,
-            final Boolean published,
+            final Optional<Publication> publication,
             final Optional<TransferChannel> uploadChannel,
             final Optional<TransferChannel> downloadChannel,
             final Queue<DomainEvent<?>> events) {
         super(id);
         this.size = size;
         this.checksum = checksum;
-        this.published = published;
+        this.publication = publication;
         this.uploadChannel = uploadChannel;
         this.downloadChannel = downloadChannel;
 
@@ -59,7 +62,7 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
             final FileId id,
             final Size size,
             final Checksum checksum,
-            final Boolean published,
+            final Publication publication,
             final TransferChannel uploadChannel,
             final TransferChannel downloadChannel,
             final Queue<DomainEvent<?>> events) {
@@ -67,7 +70,7 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
                 id,
                 size,
                 checksum,
-                published,
+                Optional.ofNullable(publication),
                 Optional.ofNullable(uploadChannel),
                 Optional.ofNullable(downloadChannel),
                 events);
@@ -91,6 +94,7 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
         else
             checksum.validate(handler);
 
+        publication.ifPresent(publication -> publication.validate(handler));
         uploadChannel.ifPresent(uploadChannel -> uploadChannel.validate(handler));
         downloadChannel.ifPresent(downloadChannel -> downloadChannel.validate(handler));
 
@@ -109,7 +113,7 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
                 id,
                 size,
                 checksum,
-                false,
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 new LinkedList<>());
@@ -119,6 +123,9 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
 
         if (isNull(transferChannel))
             throw InvalidArgumentException.with(DomainException.Error.with("'transferChannel' should not be null"));
+
+        if (isPublished())
+            throw FileAlreadyPublishedException.create(this);
 
         if (this.uploadChannel.isPresent())
             throw UploadTransferChannelAlreadyOpennedException.create();
@@ -141,19 +148,40 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
 
     }
 
-    public File publish() {
+    public File completePublication() {
 
-        if (published)
+        if (isPublished())
             return this;
 
         if (this.uploadChannel.isPresent())
             throw FileUploadInProgressException.create(this);
 
-        this.published = true;
+        this.publication = Optional.of(Publication.ok());
         events.add(FilePublishedEvent.create(this));
 
         return this;
 
+    }
+
+    public File failPublication(final Publication.Error error) {
+
+        if (isPublished())
+            throw FileAlreadyPublishedException.create(this);
+
+        if (this.uploadChannel.isPresent())
+            throw FileUploadInProgressException.create(this);
+
+        this.publication = Optional.of(Publication.error(error));
+        events.add(FilePublishFailedEvent.create(this));
+
+        return this;
+    }
+
+    public Boolean isPublished() {
+        return this.publication
+                .map(Publication::status)
+                .filter(status -> Publication.Status.OK.equals(status))
+                .isPresent();
     }
 
     private void selfValidate() {
@@ -171,8 +199,8 @@ public class File extends AggregateRoot<FileId> implements DomainEventSource {
         return checksum;
     }
 
-    public Boolean getPublished() {
-        return published;
+    public Optional<Publication> getPublication() {
+        return publication;
     }
 
     public Optional<TransferChannel> getUploadChannel() {

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/event/FilePublishFailedEvent.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/event/FilePublishFailedEvent.java
@@ -1,0 +1,36 @@
+package org.osnormais.storage.api.domain.file.event;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.osnormais.storage.api.domain.event.DomainEvent;
+import org.osnormais.storage.api.domain.event.DomainEventEntity;
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+
+public class FilePublishFailedEvent extends DomainEvent<FileId> {
+
+    private static final Class<File> ENTITY_CLASS = File.class;
+    private static final String ACTION = "publish_failed";
+
+    private FilePublishFailedEvent(
+            final File file,
+            final Instant occurredAt,
+            final Set<DomainEventEntity> relatedEntities) {
+        super(
+                file,
+                null,
+                ACTION,
+                occurredAt,
+                relatedEntities);
+    }
+
+    public static FilePublishFailedEvent create(final File file) {
+        return new FilePublishFailedEvent(file, Instant.now(), Set.of(DomainEventEntity.of(file)));
+    }
+
+    public static String eventKey() {
+        return DomainEvent.key(ENTITY_CLASS, null, ACTION);
+    }
+
+}

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/event/FilePublishedEvent.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/event/FilePublishedEvent.java
@@ -1,0 +1,37 @@
+package org.osnormais.storage.api.domain.file.event;
+
+import java.time.Instant;
+import java.util.Set;
+
+import org.osnormais.storage.api.domain.Entity;
+import org.osnormais.storage.api.domain.event.DomainEvent;
+import org.osnormais.storage.api.domain.event.DomainEventEntity;
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.FileId;
+
+public class FilePublishedEvent extends DomainEvent<FileId> {
+
+    private static final Class<? extends Entity<?>> ENTITY_CLASS = File.class;
+    private static final String ACTION = "published";
+
+    private FilePublishedEvent(
+            final File file,
+            final Instant occurredAt,
+            final Set<DomainEventEntity> relatedEntities) {
+        super(
+                file,
+                null,
+                ACTION,
+                occurredAt,
+                relatedEntities);
+    }
+
+    public static FilePublishedEvent create(final File file) {
+        return new FilePublishedEvent(file, Instant.now(), Set.of(DomainEventEntity.of(file)));
+    }
+
+    public static String eventKey() {
+        return DomainEvent.key(ENTITY_CLASS, null, ACTION);
+    }
+
+}

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Publication.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Publication.java
@@ -1,0 +1,67 @@
+package org.osnormais.storage.api.domain.file.valueobject;
+
+import static java.util.Objects.isNull;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.osnormais.storage.api.domain.ValueObject;
+import org.osnormais.storage.api.domain.validation.ValidationError;
+import org.osnormais.storage.api.domain.validation.handler.ValidationHandler;
+
+public record Publication(
+        Instant publishedAt,
+        Publication.Status status,
+        Optional<Publication.Error> error) implements ValueObject {
+
+    public static Publication ok() {
+        return new Publication(Instant.now(), Status.OK, Optional.empty());
+    }
+
+    public static Publication error(final Publication.Error error) {
+        return new Publication(Instant.now(), Status.ERROR, Optional.of(error));
+    }
+
+    @Override
+    public void validate(final ValidationHandler handler) {
+
+        if (isNull(publishedAt))
+            handler.append(new ValidationError("Publication.publishedAt should not be null"));
+
+        if (isNull(status))
+            handler.append(new ValidationError("Publication.status should not be null"));
+
+        if (isNull(error) && Status.ERROR.equals(status))
+            handler.append(new ValidationError("Publication.error should not be null when status is ERROR"));
+        else if (Status.ERROR.equals(status))
+            error.ifPresent(e -> e.validate(handler));
+
+        if (Status.OK.equals(status) && error.isPresent())
+            handler.append(new ValidationError("Publication.error should be empty when status is OK"));
+
+    }
+
+    public enum Status {
+        OK, ERROR
+    }
+
+    public record Error(String message) implements ValueObject {
+
+        public static Error of(final String message) {
+            return new Error(message);
+        }
+
+        @Override
+        public void validate(final ValidationHandler handler) {
+
+            if (isNull(message))
+                handler.append(new ValidationError("Publication.Error.message should not be null"));
+
+            if (message.isBlank())
+                handler.append(new ValidationError("Publication.Error.message should not be blank"));
+
+        }
+
+    }
+
+}

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Publication.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Publication.java
@@ -1,6 +1,7 @@
 package org.osnormais.storage.api.domain.file.valueobject;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -31,12 +32,13 @@ public record Publication(
         if (isNull(status))
             handler.append(new ValidationError("Publication.status should not be null"));
 
-        if (isNull(error) && Status.ERROR.equals(status))
-            handler.append(new ValidationError("Publication.error should not be null when status is ERROR"));
-        else if (Status.ERROR.equals(status))
+        if (nonNull(error))
             error.ifPresent(e -> e.validate(handler));
 
-        if (Status.OK.equals(status) && error.isPresent())
+        if ((isNull(error) || error.isEmpty()) && Status.ERROR.equals(status))
+            handler.append(new ValidationError("Publication.error should not be null when status is ERROR"));
+
+        if (nonNull(error) && error.isPresent() && Status.OK.equals(status))
             handler.append(new ValidationError("Publication.error should be empty when status is OK"));
 
     }
@@ -57,7 +59,7 @@ public record Publication(
             if (isNull(message))
                 handler.append(new ValidationError("Publication.Error.message should not be null"));
 
-            if (!isNull(message) && message.isBlank())
+            if (nonNull(message) && message.isBlank())
                 handler.append(new ValidationError("Publication.Error.message should not be blank"));
 
         }

--- a/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Publication.java
+++ b/domain/src/main/java/org/osnormais/storage/api/domain/file/valueobject/Publication.java
@@ -57,7 +57,7 @@ public record Publication(
             if (isNull(message))
                 handler.append(new ValidationError("Publication.Error.message should not be null"));
 
-            if (message.isBlank())
+            if (!isNull(message) && message.isBlank())
                 handler.append(new ValidationError("Publication.Error.message should not be blank"));
 
         }

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
@@ -47,6 +47,7 @@ public class FileTest {
                         expectedFileId,
                         expectedSize,
                         expectedChecksum,
+                        false,
                         expectedUploadChannel,
                         expectedDownloadChannel,
                         null));
@@ -81,6 +82,7 @@ public class FileTest {
                         expectedFileId,
                         expectedSize,
                         expectedChecksum,
+                        false,
                         expectedUploadChannel,
                         expectedDownloadChannel,
                         null));
@@ -110,6 +112,7 @@ public class FileTest {
                         expectedFileId,
                         expectedSize,
                         expectedChecksum,
+                        false,
                         expectedUploadChannel,
                         expectedDownloadChannel,
                         null));
@@ -146,6 +149,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
+                false,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);
@@ -186,6 +190,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
+                false,
                 null,
                 expectedDownloadChannel,
                 null);
@@ -221,6 +226,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
+                false,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);
@@ -270,6 +276,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
+                false,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);
@@ -358,6 +365,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
+                false,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);
@@ -394,6 +402,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
+                false,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
@@ -518,284 +518,288 @@ class FileTest {
     }
 
     @Nested
-    class CompletePublication {
+    class FinalizePublication {
 
-        @Test
-        void givenAValidUnpublishedFile_whenCallsCompletePublication_thenShouldCompletePublication() {
+        @Nested
+        class CompletePublication {
 
-            final var expectedIdValue = UUID.randomUUID();
-            final var expectedFileId = FileId.of(expectedIdValue);
-            final var expectedSize = new Size(2L);
+            @Test
+            void givenAValidUnpublishedFile_whenCallsFinalizePublication_thenShouldCompletePublication() {
 
-            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-            final var expectedChecksumValue = "123";
-            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+                final var expectedIdValue = UUID.randomUUID();
+                final var expectedFileId = FileId.of(expectedIdValue);
+                final var expectedSize = new Size(2L);
 
-            final var expectedPublicationStatus = Publication.Status.OK;
-            final TransferChannel expectedUploadChannel = null;
-            final TransferChannel expectedDownloadChannel = null;
+                final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+                final var expectedChecksumValue = "123";
+                final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm,
+                        expectedChecksumValue);
 
-            final var expectedFile = File.with(
-                    expectedFileId,
-                    expectedSize,
-                    expectedChecksum,
-                    null,
-                    expectedUploadChannel,
-                    expectedDownloadChannel,
-                    null);
+                final var expectedPublicationStatus = Publication.Status.OK;
+                final TransferChannel expectedUploadChannel = null;
+                final TransferChannel expectedDownloadChannel = null;
 
-            assertFalse(expectedFile.isPublished());
+                final var expectedFile = File.with(
+                        expectedFileId,
+                        expectedSize,
+                        expectedChecksum,
+                        null,
+                        expectedUploadChannel,
+                        expectedDownloadChannel,
+                        null);
 
-            final var actualFile = assertDoesNotThrow(() -> expectedFile.completePublication());
+                assertFalse(expectedFile.isPublished());
 
-            final var actualEvent = actualFile.nextEvent();
+                final var actualFile = assertDoesNotThrow(
+                        () -> expectedFile.finalizePublication(expectedChecksum));
 
-            assertTrue(actualFile.isPublished());
-            assertTrue(actualEvent.isPresent());
-            assertTrue(actualEvent.get() instanceof FilePublishedEvent);
+                final var actualEvent = actualFile.nextEvent();
 
-            assertEquals(expectedPublicationStatus, actualFile.getPublication().get().status());
+                assertTrue(actualFile.isPublished());
+                assertTrue(actualEvent.isPresent());
+                assertTrue(actualEvent.get() instanceof FilePublishedEvent);
 
-        }
+                assertEquals(expectedPublicationStatus, actualFile.getPublication().get().status());
 
-        @Test
-        void givenAValidPublishedFile_whenCallsCompletePublication_thenShouldNothing() {
+            }
 
-            final var expectedIdValue = UUID.randomUUID();
-            final var expectedFileId = FileId.of(expectedIdValue);
-            final var expectedSize = new Size(2L);
+            @Test
+            void givenAValidPublishedFile_whenCallsFinalizePublication_thenShouldNothing() {
 
-            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-            final var expectedChecksumValue = "123";
-            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+                final var expectedIdValue = UUID.randomUUID();
+                final var expectedFileId = FileId.of(expectedIdValue);
+                final var expectedSize = new Size(2L);
 
-            final var expectedPublication = Publication.ok();
-            final TransferChannel expectedUploadChannel = null;
-            final TransferChannel expectedDownloadChannel = null;
+                final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+                final var expectedChecksumValue = "123";
+                final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm,
+                        expectedChecksumValue);
 
-            final var expectedFile = File.with(
-                    expectedFileId,
-                    expectedSize,
-                    expectedChecksum,
-                    expectedPublication,
-                    expectedUploadChannel,
-                    expectedDownloadChannel,
-                    null);
+                final var expectedPublication = Publication.ok();
+                final TransferChannel expectedUploadChannel = null;
+                final TransferChannel expectedDownloadChannel = null;
 
-            assertTrue(expectedFile.isPublished());
+                final var expectedFile = File.with(
+                        expectedFileId,
+                        expectedSize,
+                        expectedChecksum,
+                        expectedPublication,
+                        expectedUploadChannel,
+                        expectedDownloadChannel,
+                        null);
 
-            final var actualFile = assertDoesNotThrow(() -> expectedFile.completePublication());
+                assertTrue(expectedFile.isPublished());
 
-            final var actualEvent = actualFile.nextEvent();
+                final var actualFile = assertDoesNotThrow(
+                        () -> expectedFile.finalizePublication(expectedChecksum));
 
-            assertTrue(actualFile.isPublished());
-            assertTrue(actualEvent.isEmpty());
+                final var actualEvent = actualFile.nextEvent();
 
-        }
+                assertTrue(actualFile.isPublished());
+                assertTrue(actualEvent.isEmpty());
 
-        @Test
-        void givenAValidUnpublishedFile_whenCallsCompletePublicationWithExistingUploadChannel_thenShouldThrowsFileUploadInProgressException() {
+            }
 
-            final var expectedIdValue = UUID.randomUUID();
-            final var expectedFileId = FileId.of(expectedIdValue);
-            final var expectedSize = new Size(2L);
+            @Test
+            void givenAValidUnpublishedFile_whenCallsFinalizePublicationWithExistingUploadChannel_thenShouldThrowsFileUploadInProgressException() {
 
-            final var expectedExceptionMessage = "Upload transfer channel openned for this file [%s], upload in progress"
-                    .formatted(expectedIdValue.toString());
-            final var expectedErrorsCount = 1;
-            final var expectedErrorMessage = expectedExceptionMessage
-                    + ", please close the current channel before publishing the file";
+                final var expectedIdValue = UUID.randomUUID();
+                final var expectedFileId = FileId.of(expectedIdValue);
+                final var expectedSize = new Size(2L);
 
-            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-            final var expectedChecksumValue = "123";
-            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+                final var expectedExceptionMessage = "Upload transfer channel openned for this file [%s], upload in progress"
+                        .formatted(expectedIdValue.toString());
+                final var expectedErrorsCount = 1;
+                final var expectedErrorMessage = expectedExceptionMessage
+                        + ", please close the current channel before publishing the file";
 
-            final var expectedThroughputLimit = ThroughputLimit.create(100L);
-            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
-                    ParallelChunkLimit.of(2));
+                final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+                final var expectedChecksumValue = "123";
+                final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm,
+                        expectedChecksumValue);
 
-            final Publication expectedPublication = null;
-            final var expectedUploadChannel = TransferChannel.create(
-                    expectedThroughputLimit,
-                    expectedChunkSpecification);
-            final TransferChannel expectedDownloadChannel = null;
+                final var expectedThroughputLimit = ThroughputLimit.create(100L);
+                final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
+                        ParallelChunkLimit.of(2));
 
-            final var expectedFile = File.with(
-                    expectedFileId,
-                    expectedSize,
-                    expectedChecksum,
-                    expectedPublication,
-                    expectedUploadChannel,
-                    expectedDownloadChannel,
-                    null);
+                final Publication expectedPublication = null;
+                final var expectedUploadChannel = TransferChannel.create(
+                        expectedThroughputLimit,
+                        expectedChunkSpecification);
+                final TransferChannel expectedDownloadChannel = null;
 
-            assertFalse(expectedFile.isPublished());
+                final var expectedFile = File.with(
+                        expectedFileId,
+                        expectedSize,
+                        expectedChecksum,
+                        expectedPublication,
+                        expectedUploadChannel,
+                        expectedDownloadChannel,
+                        null);
 
-            final var actualException = assertThrows(
-                    FileUploadInProgressException.class,
-                    () -> expectedFile.completePublication());
+                assertFalse(expectedFile.isPublished());
 
-            final var actualExceptionMessage = actualException.getMessage();
-            final var actualErrors = actualException.getErrors();
-            final var actualErrorsCount = actualException.getErrors().size();
+                final var actualException = assertThrows(
+                        FileUploadInProgressException.class,
+                        () -> expectedFile.finalizePublication(expectedChecksum));
 
-            assertEquals(actualExceptionMessage, expectedExceptionMessage);
-            assertEquals(expectedErrorsCount, actualErrors.size());
-            assertEquals(expectedErrorsCount, actualErrorsCount);
-            assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+                final var actualExceptionMessage = actualException.getMessage();
+                final var actualErrors = actualException.getErrors();
+                final var actualErrorsCount = actualException.getErrors().size();
 
-        }
+                assertEquals(actualExceptionMessage, expectedExceptionMessage);
+                assertEquals(expectedErrorsCount, actualErrors.size());
+                assertEquals(expectedErrorsCount, actualErrorsCount);
+                assertEquals(expectedErrorMessage, actualErrors.get(0).message());
 
-    }
-
-    @Nested
-    class FailPublication {
-
-        @Test
-        void givenAValidUnpublishedFile_whenCallsFailPublication_thenShouldFailPublication() {
-
-            final var expectedIdValue = UUID.randomUUID();
-            final var expectedFileId = FileId.of(expectedIdValue);
-            final var expectedSize = new Size(2L);
-
-            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-            final var expectedChecksumValue = "123";
-            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
-
-            final var expectedPublicationStatus = Publication.Status.ERROR;
-            final var expectedPublicationError = Publication.Error.of("pub.error");
-            final TransferChannel expectedUploadChannel = null;
-            final TransferChannel expectedDownloadChannel = null;
-
-            final var expectedFile = File.with(
-                    expectedFileId,
-                    expectedSize,
-                    expectedChecksum,
-                    null,
-                    expectedUploadChannel,
-                    expectedDownloadChannel,
-                    null);
-
-            assertFalse(expectedFile.isPublished());
-
-            final var actualFile = assertDoesNotThrow(() -> expectedFile.failPublication(expectedPublicationError));
-
-            assertFalse(actualFile.isPublished());
-            assertEquals(expectedPublicationStatus, actualFile.getPublication().get().status());
-            assertEquals(expectedPublicationError, actualFile.getPublication().get().error().get());
-
-            final var actualEvent = actualFile.nextEvent();
-            assertTrue(actualEvent.isPresent());
-            assertTrue(actualEvent.get() instanceof FilePublishFailedEvent);
-
-            assertEquals(expectedPublicationStatus, actualFile.getPublication().get().status());
+            }
 
         }
 
-        @Test
-        void givenAValidUnpublishedFile_whenCallsFailPublicationWithExistingUploadChannel_thenShouldThrowsFileUploadInProgressException() {
+        @Nested
+        class FailPublication {
 
-            final var expectedIdValue = UUID.randomUUID();
-            final var expectedFileId = FileId.of(expectedIdValue);
-            final var expectedSize = new Size(2L);
+            @Test
+            void givenAValidUnpublishedFile_whenCallsFinalizePublicationWithInvalidChecksum_thenShouldFailPublication() {
 
-            final var expectedExceptionMessage = "Upload transfer channel openned for this file [%s], upload in progress"
-                    .formatted(expectedIdValue.toString());
-            final var expectedErrorsCount = 1;
-            final var expectedErrorMessage = expectedExceptionMessage
-                    + ", please close the current channel before publishing the file";
+                final var expectedIdValue = UUID.randomUUID();
+                final var expectedFileId = FileId.of(expectedIdValue);
+                final var expectedSize = new Size(2L);
 
-            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-            final var expectedChecksumValue = "123";
-            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+                final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+                final var expectedChecksumValue = "123";
+                final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm,
+                        expectedChecksumValue);
 
-            final var expectedThroughputLimit = ThroughputLimit.create(100L);
-            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
-                    ParallelChunkLimit.of(2));
+                final var expectedPublicationStatus = Publication.Status.ERROR;
+                final var expectedPublicationError = Publication.Error.of(
+                        "File integrity compromised during finalization. Expected checksum: Checksum[algorithm=CRC_32, value=123], actual checksum: Checksum[algorithm=CRC_32, value=abc123]");
+                final TransferChannel expectedUploadChannel = null;
+                final TransferChannel expectedDownloadChannel = null;
 
-            final Publication expectedPublication = null;
-            final var expectedUploadChannel = TransferChannel.create(
-                    expectedThroughputLimit,
-                    expectedChunkSpecification);
-            final TransferChannel expectedDownloadChannel = null;
+                final var expectedFile = File.with(
+                        expectedFileId,
+                        expectedSize,
+                        expectedChecksum,
+                        null,
+                        expectedUploadChannel,
+                        expectedDownloadChannel,
+                        null);
 
-            final var expectedFile = File.with(
-                    expectedFileId,
-                    expectedSize,
-                    expectedChecksum,
-                    expectedPublication,
-                    expectedUploadChannel,
-                    expectedDownloadChannel,
-                    null);
+                assertFalse(expectedFile.isPublished());
 
-            final var expectedPublicationError = Publication.Error.of("pub.error");
+                final var actualFile = assertDoesNotThrow(() -> expectedFile
+                        .finalizePublication(Checksum.of(expectedChecksumAlgorithm, "abc123")));
 
-            assertFalse(expectedFile.isPublished());
+                assertFalse(actualFile.isPublished());
+                assertEquals(expectedPublicationStatus, actualFile.getPublication().get().status());
+                assertEquals(expectedPublicationError, actualFile.getPublication().get().error().get());
 
-            final var actualException = assertThrows(
-                    FileUploadInProgressException.class,
-                    () -> expectedFile.failPublication(expectedPublicationError));
+                final var actualEvent = actualFile.nextEvent();
+                assertTrue(actualEvent.isPresent());
+                assertTrue(actualEvent.get() instanceof FilePublishFailedEvent);
 
-            final var actualExceptionMessage = actualException.getMessage();
-            final var actualErrors = actualException.getErrors();
-            final var actualErrorsCount = actualException.getErrors().size();
+                assertEquals(expectedPublicationStatus, actualFile.getPublication().get().status());
 
-            assertEquals(actualExceptionMessage, expectedExceptionMessage);
-            assertEquals(expectedErrorsCount, actualErrors.size());
-            assertEquals(expectedErrorsCount, actualErrorsCount);
-            assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+            }
 
-        }
+            @Test
+            void givenAValidUnpublishedFile_whenCallsFinalizePublicationWithExistingUploadChannel_thenShouldThrowsFileUploadInProgressException() {
 
-        @Test
-        void givenAValidPublishedFile_whenCallsFailPublicationWithExistingUploadChannel_thenShouldThrowsFileAlreadyPublishedException() {
+                final var expectedIdValue = UUID.randomUUID();
+                final var expectedFileId = FileId.of(expectedIdValue);
+                final var expectedSize = new Size(2L);
 
-            final var expectedIdValue = UUID.randomUUID();
-            final var expectedFileId = FileId.of(expectedIdValue);
-            final var expectedSize = new Size(2L);
+                final var expectedExceptionMessage = "Upload transfer channel openned for this file [%s], upload in progress"
+                        .formatted(expectedIdValue.toString());
+                final var expectedErrorsCount = 1;
+                final var expectedErrorMessage = expectedExceptionMessage
+                        + ", please close the current channel before publishing the file";
 
-            final var expectedExceptionMessage = "File [%s], already published"
-                    .formatted(expectedIdValue.toString());
-            final var expectedErrorsCount = 0;
+                final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+                final var expectedChecksumValue = "123";
+                final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm,
+                        expectedChecksumValue);
 
-            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-            final var expectedChecksumValue = "123";
-            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+                final var expectedThroughputLimit = ThroughputLimit.create(100L);
+                final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
+                        ParallelChunkLimit.of(2));
 
-            final var expectedThroughputLimit = ThroughputLimit.create(100L);
-            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
-                    ParallelChunkLimit.of(2));
+                final Publication expectedPublication = null;
+                final var expectedUploadChannel = TransferChannel.create(
+                        expectedThroughputLimit,
+                        expectedChunkSpecification);
+                final TransferChannel expectedDownloadChannel = null;
 
-            final Publication expectedPublication = Publication.ok();
-            final var expectedUploadChannel = TransferChannel.create(
-                    expectedThroughputLimit,
-                    expectedChunkSpecification);
-            final TransferChannel expectedDownloadChannel = null;
+                final var expectedFile = File.with(
+                        expectedFileId,
+                        expectedSize,
+                        expectedChecksum,
+                        expectedPublication,
+                        expectedUploadChannel,
+                        expectedDownloadChannel,
+                        null);
 
-            final var expectedFile = File.with(
-                    expectedFileId,
-                    expectedSize,
-                    expectedChecksum,
-                    expectedPublication,
-                    expectedUploadChannel,
-                    expectedDownloadChannel,
-                    null);
+                assertFalse(expectedFile.isPublished());
 
-            final var expectedPublicationError = Publication.Error.of("pub.error");
+                final var actualException = assertThrows(
+                        FileUploadInProgressException.class,
+                        () -> expectedFile.finalizePublication(expectedChecksum));
 
-            assertTrue(expectedFile.isPublished());
+                final var actualExceptionMessage = actualException.getMessage();
+                final var actualErrors = actualException.getErrors();
+                final var actualErrorsCount = actualException.getErrors().size();
 
-            final var actualException = assertThrows(
-                    FileAlreadyPublishedException.class,
-                    () -> expectedFile.failPublication(expectedPublicationError));
+                assertEquals(actualExceptionMessage, expectedExceptionMessage);
+                assertEquals(expectedErrorsCount, actualErrors.size());
+                assertEquals(expectedErrorsCount, actualErrorsCount);
+                assertEquals(expectedErrorMessage, actualErrors.get(0).message());
 
-            final var actualExceptionMessage = actualException.getMessage();
-            final var actualErrors = actualException.getErrors();
-            final var actualErrorsCount = actualException.getErrors().size();
+            }
 
-            assertEquals(actualExceptionMessage, expectedExceptionMessage);
-            assertEquals(expectedErrorsCount, actualErrors.size());
-            assertEquals(expectedErrorsCount, actualErrorsCount);
+            @Test
+            void givenAValidPublishedFile_whenCallsFinalizePublicationWithExistingUploadChannel_thenShouldThrowsFileAlreadyPublishedException() {
+
+                final var expectedIdValue = UUID.randomUUID();
+                final var expectedFileId = FileId.of(expectedIdValue);
+                final var expectedSize = new Size(2L);
+
+                final var expectedExceptionMessage = "File [%s], already published"
+                        .formatted(expectedIdValue.toString());
+                final var expectedErrorsCount = 0;
+
+                final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+                final var expectedChecksumValue = "123";
+                final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+                final Publication expectedPublication = Publication.ok();
+                final TransferChannel expectedUploadChannel = null;
+                final TransferChannel expectedDownloadChannel = null;
+
+                final var expectedFile = File.with(
+                        expectedFileId,
+                        expectedSize,
+                        expectedChecksum,
+                        expectedPublication,
+                        expectedUploadChannel,
+                        expectedDownloadChannel,
+                        null);
+
+                assertTrue(expectedFile.isPublished());
+
+                final var actualException = assertThrows(
+                        FileAlreadyPublishedException.class,
+                        () -> expectedFile.finalizePublication(Checksum.of(expectedChecksumAlgorithm, "abc123")));
+
+                final var actualExceptionMessage = actualException.getMessage();
+                final var actualErrors = actualException.getErrors();
+                final var actualErrorsCount = actualException.getErrors().size();
+
+                assertEquals(actualExceptionMessage, expectedExceptionMessage);
+                assertEquals(expectedErrorsCount, actualErrors.size());
+                assertEquals(expectedErrorsCount, actualErrorsCount);
+
+            }
 
         }
 

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
@@ -2,420 +2,802 @@ package org.osnormais.storage.api.domain.file;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 import java.util.UUID;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.osnormais.storage.api.domain.exception.FileAlreadyPublishedException;
+import org.osnormais.storage.api.domain.exception.FileUploadInProgressException;
 import org.osnormais.storage.api.domain.exception.InvalidArgumentException;
 import org.osnormais.storage.api.domain.exception.UploadTransferChannelAlreadyOpennedException;
 import org.osnormais.storage.api.domain.exception.ValidationException;
+import org.osnormais.storage.api.domain.file.event.FilePublishFailedEvent;
+import org.osnormais.storage.api.domain.file.event.FilePublishedEvent;
 import org.osnormais.storage.api.domain.file.event.FileUploadTransferChannelCompletedEvent;
 import org.osnormais.storage.api.domain.file.valueobject.Checksum;
 import org.osnormais.storage.api.domain.file.valueobject.ChunkSpecification;
 import org.osnormais.storage.api.domain.file.valueobject.ParallelChunkLimit;
+import org.osnormais.storage.api.domain.file.valueobject.Publication;
 import org.osnormais.storage.api.domain.file.valueobject.Size;
 import org.osnormais.storage.api.domain.file.valueobject.ThroughputLimit;
 import org.osnormais.storage.api.domain.file.valueobject.TransferChannel;
 import org.osnormais.storage.api.domain.validation.handler.Notification;
 
-public class FileTest {
+class FileTest {
 
-    @Test
-    void givenNegativeSize_whenInstantiateUsingWith_thenShouldThrowsValidationException() {
+    @Nested
+    class With {
 
-        final var expectedExceptionMessage = "'File' validation failed";
-        final var expectedErrorsCount = 1;
-        final var expectedErrorMessage = "bytes must be greater than 0";
+        @Test
+        void givenNegativeSize_whenInstantiateUsingWith_thenShouldThrowsValidationException() {
 
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final var expectedSize = new Size(-2L);
+            final var expectedExceptionMessage = "'File' validation failed";
+            final var expectedErrorsCount = 1;
+            final var expectedErrorMessage = "bytes must be greater than 0";
 
-        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-        final var expectedChecksumValue = "123";
-        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(-2L);
 
-        final TransferChannel expectedUploadChannel = null;
-        final TransferChannel expectedDownloadChannel = null;
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
-        final var actualException = assertThrows(
-                ValidationException.class,
-                () -> File.with(
-                        expectedFileId,
-                        expectedSize,
-                        expectedChecksum,
-                        null,
-                        expectedUploadChannel,
-                        expectedDownloadChannel,
-                        null));
+            final Publication expectedPublication = null;
+            final TransferChannel expectedUploadChannel = null;
+            final TransferChannel expectedDownloadChannel = null;
 
-        final var actualExceptionMessage = actualException.getMessage();
-        final var actualErrors = actualException.getErrors();
-        final var actualErrorsCount = actualException.getErrors().size();
+            final var actualException = assertThrows(
+                    ValidationException.class,
+                    () -> File.with(
+                            expectedFileId,
+                            expectedSize,
+                            expectedChecksum,
+                            expectedPublication,
+                            expectedUploadChannel,
+                            expectedDownloadChannel,
+                            null));
 
-        assertEquals(actualExceptionMessage, expectedExceptionMessage);
-        assertEquals(expectedErrorsCount, actualErrors.size());
-        assertEquals(expectedErrorsCount, actualErrorsCount);
-        assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+            final var actualExceptionMessage = actualException.getMessage();
+            final var actualErrors = actualException.getErrors();
+            final var actualErrorsCount = actualException.getErrors().size();
 
-    }
+            assertEquals(actualExceptionMessage, expectedExceptionMessage);
+            assertEquals(expectedErrorsCount, actualErrors.size());
+            assertEquals(expectedErrorsCount, actualErrorsCount);
+            assertEquals(expectedErrorMessage, actualErrors.get(0).message());
 
-    @Test
-    void givenNullId_whenInstantiateUsingWith_thenShouldThrowsNullPointerException() {
+        }
 
-        final FileId expectedFileId = null;
-        final var expectedSize = new Size(2L);
+        @Test
+        void givenNullId_whenInstantiateUsingWith_thenShouldThrowsNullPointerException() {
 
-        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-        final var expectedChecksumValue = "123";
-        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+            final FileId expectedFileId = null;
+            final var expectedSize = new Size(2L);
 
-        final TransferChannel expectedUploadChannel = null;
-        final TransferChannel expectedDownloadChannel = null;
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
-        final var actualException = assertThrows(
-                NullPointerException.class,
-                () -> File.with(
-                        expectedFileId,
-                        expectedSize,
-                        expectedChecksum,
-                        null,
-                        expectedUploadChannel,
-                        expectedDownloadChannel,
-                        null));
-        assertEquals("'id' should not be null", actualException.getMessage());
+            final Publication expectedPublication = null;
+            final TransferChannel expectedUploadChannel = null;
+            final TransferChannel expectedDownloadChannel = null;
 
-    }
+            final var actualException = assertThrows(
+                    NullPointerException.class,
+                    () -> File.with(
+                            expectedFileId,
+                            expectedSize,
+                            expectedChecksum,
+                            expectedPublication,
+                            expectedUploadChannel,
+                            expectedDownloadChannel,
+                            null));
+            assertEquals("'id' should not be null", actualException.getMessage());
 
-    @Test
-    void givenNullChecksum_whenInstantiateUsingWith_thenShouldThrowsValidationException() {
+        }
 
-        final var expectedExceptionMessage = "'File' validation failed";
-        final var expectedErrorsCount = 1;
-        final var expectedErrorMessage = "checksum cant be null";
+        @Test
+        void givenNullChecksum_whenInstantiateUsingWith_thenShouldThrowsValidationException() {
 
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final var expectedSize = new Size(2L);
+            final var expectedExceptionMessage = "'File' validation failed";
+            final var expectedErrorsCount = 1;
+            final var expectedErrorMessage = "checksum cant be null";
 
-        final Checksum expectedChecksum = null;
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
 
-        final TransferChannel expectedUploadChannel = null;
-        final TransferChannel expectedDownloadChannel = null;
+            final Checksum expectedChecksum = null;
 
-        final var actualException = assertThrows(
-                ValidationException.class,
-                () -> File.with(
-                        expectedFileId,
-                        expectedSize,
-                        expectedChecksum,
-                        null,
-                        expectedUploadChannel,
-                        expectedDownloadChannel,
-                        null));
+            final Publication expectedPublication = null;
+            final TransferChannel expectedUploadChannel = null;
+            final TransferChannel expectedDownloadChannel = null;
 
-        final var actualExceptionMessage = actualException.getMessage();
-        final var actualErrors = actualException.getErrors();
-        final var actualErrorsCount = actualException.getErrors().size();
+            final var actualException = assertThrows(
+                    ValidationException.class,
+                    () -> File.with(
+                            expectedFileId,
+                            expectedSize,
+                            expectedChecksum,
+                            expectedPublication,
+                            expectedUploadChannel,
+                            expectedDownloadChannel,
+                            null));
 
-        assertEquals(actualExceptionMessage, expectedExceptionMessage);
-        assertEquals(expectedErrorsCount, actualErrors.size());
-        assertEquals(expectedErrorsCount, actualErrorsCount);
-        assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+            final var actualExceptionMessage = actualException.getMessage();
+            final var actualErrors = actualException.getErrors();
+            final var actualErrorsCount = actualException.getErrors().size();
 
-    }
+            assertEquals(actualExceptionMessage, expectedExceptionMessage);
+            assertEquals(expectedErrorsCount, actualErrors.size());
+            assertEquals(expectedErrorsCount, actualErrorsCount);
+            assertEquals(expectedErrorMessage, actualErrors.get(0).message());
 
-    @Test
-    void givenValidFile_whenValidate_thenHandlerShouldNotAppendError() {
-
-        final var expectedErrorsCount = 0;
-        final var expectedHasErrors = false;
-
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final var expectedSize = new Size(2L);
-
-        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-        final var expectedChecksumValue = "123";
-        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
-
-        final TransferChannel expectedUploadChannel = null;
-        final TransferChannel expectedDownloadChannel = null;
-
-        final var expectedFile = File.with(
-                expectedFileId,
-                expectedSize,
-                expectedChecksum,
-                null,
-                expectedUploadChannel,
-                expectedDownloadChannel,
-                null);
-
-        final var handler = Notification.create();
-
-        expectedFile.validate(handler);
-
-        final var actualHasErrors = handler.hasErrors();
-        final var actualErrors = handler.getErrors();
-
-        assertEquals(expectedErrorsCount, actualErrors.size());
-        assertEquals(expectedHasErrors, actualHasErrors);
+        }
 
     }
 
-    @Test
-    void givenValidTransferChannel_whenCallsOpenUploadChannel_thenShouldOpenChannel() {
+    @Nested
+    class Validate {
 
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final var expectedSize = new Size(2L);
+        @Test
+        void givenValidFile_whenValidate_thenHandlerShouldNotAppendError() {
 
-        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-        final var expectedChecksumValue = "123";
-        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+            final var expectedErrorsCount = 0;
+            final var expectedHasErrors = false;
 
-        final var expectedThroughputLimit = ThroughputLimit.create(100L);
-        final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L), ParallelChunkLimit.of(2));
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
 
-        final var expectedUploadChannel = TransferChannel.create(
-                expectedThroughputLimit,
-                expectedChunkSpecification);
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
-        final TransferChannel expectedDownloadChannel = null;
+            final Publication expectedPublication = null;
+            final TransferChannel expectedUploadChannel = null;
+            final TransferChannel expectedDownloadChannel = null;
 
-        final var expectedFile = File.with(
-                expectedFileId,
-                expectedSize,
-                expectedChecksum,
-                null,
-                null,
-                expectedDownloadChannel,
-                null);
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
 
-        assertTrue(expectedFile.getUploadChannel().isEmpty());
+            final var handler = Notification.create();
 
-        assertDoesNotThrow(() -> expectedFile.openUploadChannel(expectedUploadChannel));
+            expectedFile.validate(handler);
 
-        assertTrue(expectedFile.getUploadChannel().isPresent());
-        assertEquals(expectedUploadChannel, expectedFile.getUploadChannel().get());
+            final var actualHasErrors = handler.hasErrors();
+            final var actualErrors = handler.getErrors();
 
-    }
+            assertEquals(expectedErrorsCount, actualErrors.size());
+            assertEquals(expectedHasErrors, actualHasErrors);
 
-    @Test
-    void givenNullTransferChannel_whenCallsOpenUploadChannel_thenShouldThrowsInvalidArgumentException() {
-
-        final var expectedExceptionMessage = "Invalid argument provided.";
-        final var expectedErrorsCount = 1;
-        final var expectedErrorMessage = "'transferChannel' should not be null";
-
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final var expectedSize = new Size(2L);
-
-        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-        final var expectedChecksumValue = "123";
-        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
-
-        final TransferChannel expectedUploadChannel = null;
-        final TransferChannel expectedDownloadChannel = null;
-
-        final var expectedFile = File.with(
-                expectedFileId,
-                expectedSize,
-                expectedChecksum,
-                null,
-                expectedUploadChannel,
-                expectedDownloadChannel,
-                null);
-
-        assertTrue(expectedFile.getUploadChannel().isEmpty());
-
-        final var actualException = assertThrows(
-                InvalidArgumentException.class,
-                () -> expectedFile.openUploadChannel(expectedUploadChannel));
-
-        final var actualExceptionMessage = actualException.getMessage();
-        final var actualErrors = actualException.getErrors();
-        final var actualErrorsCount = actualException.getErrors().size();
-
-        assertEquals(actualExceptionMessage, expectedExceptionMessage);
-        assertEquals(expectedErrorsCount, actualErrors.size());
-        assertEquals(expectedErrorsCount, actualErrorsCount);
-        assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+        }
 
     }
 
-    @Test
-    void givenValidTransferChannel_whenCallsOpenUploadChannelWithAlreadyOpenChannel_thenShouldOpenChannel() {
+    @Nested
+    class Create {
 
-        final var expectedExceptionMessage = "Upload transfer channel already open";
-        final var expectedErrorsCount = 1;
-        final var expectedErrorMessage = "Upload transfer channel already open, please close the current channel before opening a new one";
+        @Test
+        void givenValidArguments_whenCallsCreate_thenShouldCreateFile() {
 
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final var expectedSize = new Size(2L);
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
 
-        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-        final var expectedChecksumValue = "123";
-        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
-        final var expectedThroughputLimit = ThroughputLimit.create(100L);
-        final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L), ParallelChunkLimit.of(2));
+            final var expectedPublication = Optional.<Publication>empty();
+            final var expectedUploadChannel = Optional.<TransferChannel>empty();
+            final var expectedDownloadChannel = Optional.<TransferChannel>empty();
 
-        final var expectedUploadChannel = TransferChannel.create(
-                expectedThroughputLimit,
-                expectedChunkSpecification);
+            final var actualFile = assertDoesNotThrow(
+                    () -> File.create(expectedFileId, expectedSize, expectedChecksum));
 
-        final TransferChannel expectedDownloadChannel = null;
+            assertEquals(expectedIdValue, actualFile.getId().getValue());
+            assertEquals(expectedFileId, actualFile.getId());
+            assertEquals(expectedSize, actualFile.getSize());
+            assertEquals(expectedChecksum, actualFile.getChecksum());
+            assertEquals(expectedPublication, actualFile.getPublication());
+            assertEquals(expectedUploadChannel, actualFile.getUploadChannel());
+            assertEquals(expectedDownloadChannel, actualFile.getDownloadChannel());
 
-        final var expectedFile = File.with(
-                expectedFileId,
-                expectedSize,
-                expectedChecksum,
-                null,
-                expectedUploadChannel,
-                expectedDownloadChannel,
-                null);
+        }
 
-        assertTrue(expectedFile.getUploadChannel().isPresent());
+        @Test
+        void givenNullArguments_whenCallsCreate_thenShouldThrowsValidationException() {
 
-        final var actualException = assertThrows(
-                UploadTransferChannelAlreadyOpennedException.class,
-                () -> expectedFile.openUploadChannel(expectedUploadChannel));
+            final var expectedExceptionMessage = "'File' validation failed";
 
-        final var actualExceptionMessage = actualException.getMessage();
-        final var actualErrors = actualException.getErrors();
-        final var actualErrorsCount = actualException.getErrors().size();
+            final var expectedErrorCount = 2;
+            final var expectedErrorMessage0 = "size cant be null";
+            final var expectedErrorMessage1 = "checksum cant be null";
 
-        assertEquals(actualExceptionMessage, expectedExceptionMessage);
-        assertEquals(expectedErrorsCount, actualErrors.size());
-        assertEquals(expectedErrorsCount, actualErrorsCount);
-        assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final Size expectedSize = null;
+            final Checksum expectedChecksum = null;
 
-    }
+            final var actualException = assertThrows(ValidationException.class,
+                    () -> File.create(expectedFileId, expectedSize, expectedChecksum));
 
-    @Test
-    void givenValidArguments_whenCallsCreate_thenShouldCreateFile() {
+            assertEquals(actualException.getMessage(), expectedExceptionMessage);
+            assertEquals(actualException.getErrors().size(), expectedErrorCount);
+            assertEquals(actualException.getErrors().get(0).message(), expectedErrorMessage0);
+            assertEquals(actualException.getErrors().get(1).message(), expectedErrorMessage1);
 
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final var expectedSize = new Size(2L);
-
-        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-        final var expectedChecksumValue = "123";
-        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
-
-        final var expectedUploadChannel = Optional.<TransferChannel>empty();
-        final var expectedDownloadChannel = Optional.<TransferChannel>empty();
-
-        final var actualFile = assertDoesNotThrow(() -> File.create(expectedFileId, expectedSize, expectedChecksum));
-
-        assertEquals(expectedIdValue, actualFile.getId().getValue());
-        assertEquals(expectedFileId, actualFile.getId());
-        assertEquals(expectedSize, actualFile.getSize());
-        assertEquals(expectedChecksum, actualFile.getChecksum());
-        assertEquals(expectedUploadChannel, actualFile.getUploadChannel());
-        assertEquals(expectedDownloadChannel, actualFile.getDownloadChannel());
+        }
 
     }
 
-    @Test
-    void givenNullArguments_whenCallsCreate_thenShouldThrowsValidationException() {
+    @Nested
+    class OpenUploadChannel {
 
-        final var expectedExceptionMessage = "'File' validation failed";
+        @Test
+        void givenValidTransferChannel_whenCallsOpenUploadChannel_thenShouldOpenChannel() {
 
-        final var expectedErrorCount = 2;
-        final var expectedErrorMessage0 = "size cant be null";
-        final var expectedErrorMessage1 = "checksum cant be null";
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
 
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final Size expectedSize = null;
-        final Checksum expectedChecksum = null;
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
-        final var actualException = assertThrows(ValidationException.class,
-                () -> File.create(expectedFileId, expectedSize, expectedChecksum));
+            final var expectedThroughputLimit = ThroughputLimit.create(100L);
+            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
+                    ParallelChunkLimit.of(2));
 
-        assertEquals(actualException.getMessage(), expectedExceptionMessage);
-        assertEquals(actualException.getErrors().size(), expectedErrorCount);
-        assertEquals(actualException.getErrors().get(0).message(), expectedErrorMessage0);
-        assertEquals(actualException.getErrors().get(1).message(), expectedErrorMessage1);
+            final Publication expectedPublication = null;
+            final var expectedUploadChannel = TransferChannel.create(
+                    expectedThroughputLimit,
+                    expectedChunkSpecification);
+
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    null,
+                    expectedDownloadChannel,
+                    null);
+
+            assertTrue(expectedFile.getUploadChannel().isEmpty());
+
+            assertDoesNotThrow(() -> expectedFile.openUploadChannel(expectedUploadChannel));
+
+            assertTrue(expectedFile.getUploadChannel().isPresent());
+            assertEquals(expectedUploadChannel, expectedFile.getUploadChannel().get());
+
+        }
+
+        @Test
+        void givenNullTransferChannel_whenCallsOpenUploadChannel_thenShouldThrowsInvalidArgumentException() {
+
+            final var expectedExceptionMessage = "Invalid argument provided.";
+            final var expectedErrorsCount = 1;
+            final var expectedErrorMessage = "'transferChannel' should not be null";
+
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
+
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+            final Publication expectedPublication = null;
+            final TransferChannel expectedUploadChannel = null;
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
+
+            assertTrue(expectedFile.getUploadChannel().isEmpty());
+
+            final var actualException = assertThrows(
+                    InvalidArgumentException.class,
+                    () -> expectedFile.openUploadChannel(expectedUploadChannel));
+
+            final var actualExceptionMessage = actualException.getMessage();
+            final var actualErrors = actualException.getErrors();
+            final var actualErrorsCount = actualException.getErrors().size();
+
+            assertEquals(actualExceptionMessage, expectedExceptionMessage);
+            assertEquals(expectedErrorsCount, actualErrors.size());
+            assertEquals(expectedErrorsCount, actualErrorsCount);
+            assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+
+        }
+
+        @Test
+        void givenValidTransferChannel_whenCallsOpenUploadChannelWithAlreadyOpenChannel_thenShouldThrowsUploadTransferChannelAlreadyOpennedException() {
+
+            final var expectedExceptionMessage = "Upload transfer channel already open";
+            final var expectedErrorsCount = 1;
+            final var expectedErrorMessage = "Upload transfer channel already open, please close the current channel before opening a new one";
+
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
+
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+            final Publication expectedPublication = null;
+            final var expectedThroughputLimit = ThroughputLimit.create(100L);
+            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
+                    ParallelChunkLimit.of(2));
+
+            final var expectedUploadChannel = TransferChannel.create(
+                    expectedThroughputLimit,
+                    expectedChunkSpecification);
+
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
+
+            assertTrue(expectedFile.getUploadChannel().isPresent());
+
+            final var actualException = assertThrows(
+                    UploadTransferChannelAlreadyOpennedException.class,
+                    () -> expectedFile.openUploadChannel(expectedUploadChannel));
+
+            final var actualExceptionMessage = actualException.getMessage();
+            final var actualErrors = actualException.getErrors();
+            final var actualErrorsCount = actualException.getErrors().size();
+
+            assertEquals(actualExceptionMessage, expectedExceptionMessage);
+            assertEquals(expectedErrorsCount, actualErrors.size());
+            assertEquals(expectedErrorsCount, actualErrorsCount);
+            assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+
+        }
+
+        @Test
+        void givenValidTransferChannel_whenCallsOpenUploadChannelWithAlreadyPublishedFile_thenShouldThrowsFileAlreadyPublishedException() {
+
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
+
+            final var expectedExceptionMessage = "File [%s], already published"
+                    .formatted(expectedIdValue.toString());
+            final var expectedErrorsCount = 0;
+
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+            final var expectedPublication = Publication.ok();
+            final var expectedThroughputLimit = ThroughputLimit.create(100L);
+            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
+                    ParallelChunkLimit.of(2));
+
+            final var expectedUploadChannel = TransferChannel.create(
+                    expectedThroughputLimit,
+                    expectedChunkSpecification);
+
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
+
+            assertTrue(expectedFile.getUploadChannel().isPresent());
+
+            final var actualException = assertThrows(
+                    FileAlreadyPublishedException.class,
+                    () -> expectedFile.openUploadChannel(expectedUploadChannel));
+
+            final var actualExceptionMessage = actualException.getMessage();
+            final var actualErrors = actualException.getErrors();
+            final var actualErrorsCount = actualException.getErrors().size();
+
+            assertEquals(actualExceptionMessage, expectedExceptionMessage);
+            assertEquals(expectedErrorsCount, actualErrors.size());
+            assertEquals(expectedErrorsCount, actualErrorsCount);
+
+        }
 
     }
 
-    @Test
-    void givenAnEmptyUploadChannel_whenCallsCompleteUploadChannel_thenShouldNotCompleteChannel() {
+    @Nested
+    class CompleteUploadChannel {
 
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final var expectedSize = new Size(2L);
+        @Test
+        void givenAnEmptyUploadChannel_whenCallsCompleteUploadChannel_thenShouldNotCompleteChannel() {
 
-        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-        final var expectedChecksumValue = "123";
-        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
 
-        final TransferChannel expectedUploadChannel = null;
-        final TransferChannel expectedDownloadChannel = null;
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
-        final var expectedFile = File.with(
-                expectedFileId,
-                expectedSize,
-                expectedChecksum,
-                null,
-                expectedUploadChannel,
-                expectedDownloadChannel,
-                null);
+            final Publication expectedPublication = null;
+            final TransferChannel expectedUploadChannel = null;
+            final TransferChannel expectedDownloadChannel = null;
 
-        assertTrue(expectedFile.getUploadChannel().isEmpty());
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
 
-        final var actualFile = assertDoesNotThrow(() -> expectedFile.completeUploadChannel());
+            assertTrue(expectedFile.getUploadChannel().isEmpty());
 
-        assertTrue(actualFile.getUploadChannel().isEmpty());
-        assertTrue(actualFile.nextEvent().isEmpty());
+            final var actualFile = assertDoesNotThrow(() -> expectedFile.completeUploadChannel());
+
+            assertTrue(actualFile.getUploadChannel().isEmpty());
+            assertTrue(actualFile.nextEvent().isEmpty());
+
+        }
+
+        @Test
+        void givenAnPopulatedUploadChannel_whenCallsCompleteUploadChannel_thenShouldCompleteChannel() {
+
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
+
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+            final var expectedThroughputLimit = ThroughputLimit.create(100L);
+            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
+                    ParallelChunkLimit.of(2));
+
+            final Publication expectedPublication = null;
+            final var expectedUploadChannel = TransferChannel.create(
+                    expectedThroughputLimit,
+                    expectedChunkSpecification);
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
+
+            assertTrue(expectedFile.getUploadChannel().isPresent());
+
+            final var actualFile = assertDoesNotThrow(() -> expectedFile.completeUploadChannel());
+
+            final var actualEvent = actualFile.nextEvent();
+
+            assertTrue(actualFile.getUploadChannel().isEmpty());
+            assertTrue(actualEvent.isPresent());
+            assertTrue(actualEvent.get() instanceof FileUploadTransferChannelCompletedEvent);
+
+        }
 
     }
 
-    @Test
-    void givenAnPopulatedUploadChannel_whenCallsCompleteUploadChannel_thenShouldCompleteChannel() {
+    @Nested
+    class CompletePublication {
 
-        final var expectedIdValue = UUID.randomUUID();
-        final var expectedFileId = FileId.of(expectedIdValue);
-        final var expectedSize = new Size(2L);
+        @Test
+        void givenAValidUnpublishedFile_whenCallsCompletePublication_thenShouldCompletePublication() {
 
-        final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
-        final var expectedChecksumValue = "123";
-        final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
 
-        final var expectedThroughputLimit = ThroughputLimit.create(100L);
-        final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L), ParallelChunkLimit.of(2));
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
 
-        final var expectedUploadChannel = TransferChannel.create(
-                expectedThroughputLimit,
-                expectedChunkSpecification);
-        final TransferChannel expectedDownloadChannel = null;
+            final var expectedPublicationStatus = Publication.Status.OK;
+            final TransferChannel expectedUploadChannel = null;
+            final TransferChannel expectedDownloadChannel = null;
 
-        final var expectedFile = File.with(
-                expectedFileId,
-                expectedSize,
-                expectedChecksum,
-                null,
-                expectedUploadChannel,
-                expectedDownloadChannel,
-                null);
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    null,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
 
-        assertTrue(expectedFile.getUploadChannel().isPresent());
+            assertFalse(expectedFile.isPublished());
 
-        final var actualFile = assertDoesNotThrow(() -> expectedFile.completeUploadChannel());
+            final var actualFile = assertDoesNotThrow(() -> expectedFile.completePublication());
 
-        final var actualEvent = actualFile.nextEvent();
+            final var actualEvent = actualFile.nextEvent();
 
-        assertTrue(actualFile.getUploadChannel().isEmpty());
-        assertTrue(actualEvent.isPresent());
-        assertTrue(actualEvent.get() instanceof FileUploadTransferChannelCompletedEvent);
+            assertTrue(actualFile.isPublished());
+            assertTrue(actualEvent.isPresent());
+            assertTrue(actualEvent.get() instanceof FilePublishedEvent);
+
+            assertEquals(expectedPublicationStatus, actualFile.getPublication().get().status());
+
+        }
+
+        @Test
+        void givenAValidPublishedFile_whenCallsCompletePublication_thenShouldNothing() {
+
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
+
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+            final var expectedPublication = Publication.ok();
+            final TransferChannel expectedUploadChannel = null;
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
+
+            assertTrue(expectedFile.isPublished());
+
+            final var actualFile = assertDoesNotThrow(() -> expectedFile.completePublication());
+
+            final var actualEvent = actualFile.nextEvent();
+
+            assertTrue(actualFile.isPublished());
+            assertTrue(actualEvent.isEmpty());
+
+        }
+
+        @Test
+        void givenAValidUnpublishedFile_whenCallsCompletePublicationWithExistingUploadChannel_thenShouldThrowsFileUploadInProgressException() {
+
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
+
+            final var expectedExceptionMessage = "Upload transfer channel openned for this file [%s], upload in progress"
+                    .formatted(expectedIdValue.toString());
+            final var expectedErrorsCount = 1;
+            final var expectedErrorMessage = expectedExceptionMessage
+                    + ", please close the current channel before publishing the file";
+
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+            final var expectedThroughputLimit = ThroughputLimit.create(100L);
+            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
+                    ParallelChunkLimit.of(2));
+
+            final Publication expectedPublication = null;
+            final var expectedUploadChannel = TransferChannel.create(
+                    expectedThroughputLimit,
+                    expectedChunkSpecification);
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
+
+            assertFalse(expectedFile.isPublished());
+
+            final var actualException = assertThrows(
+                    FileUploadInProgressException.class,
+                    () -> expectedFile.completePublication());
+
+            final var actualExceptionMessage = actualException.getMessage();
+            final var actualErrors = actualException.getErrors();
+            final var actualErrorsCount = actualException.getErrors().size();
+
+            assertEquals(actualExceptionMessage, expectedExceptionMessage);
+            assertEquals(expectedErrorsCount, actualErrors.size());
+            assertEquals(expectedErrorsCount, actualErrorsCount);
+            assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+
+        }
+
+    }
+
+    @Nested
+    class FailPublication {
+
+        @Test
+        void givenAValidUnpublishedFile_whenCallsFailPublication_thenShouldFailPublication() {
+
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
+
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+            final var expectedPublicationStatus = Publication.Status.ERROR;
+            final var expectedPublicationError = Publication.Error.of("pub.error");
+            final TransferChannel expectedUploadChannel = null;
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    null,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
+
+            assertFalse(expectedFile.isPublished());
+
+            final var actualFile = assertDoesNotThrow(() -> expectedFile.failPublication(expectedPublicationError));
+
+            assertFalse(actualFile.isPublished());
+            assertEquals(expectedPublicationStatus, actualFile.getPublication().get().status());
+            assertEquals(expectedPublicationError, actualFile.getPublication().get().error().get());
+
+            final var actualEvent = actualFile.nextEvent();
+            assertTrue(actualEvent.isPresent());
+            assertTrue(actualEvent.get() instanceof FilePublishFailedEvent);
+
+            assertEquals(expectedPublicationStatus, actualFile.getPublication().get().status());
+
+        }
+
+        @Test
+        void givenAValidUnpublishedFile_whenCallsFailPublicationWithExistingUploadChannel_thenShouldThrowsFileUploadInProgressException() {
+
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
+
+            final var expectedExceptionMessage = "Upload transfer channel openned for this file [%s], upload in progress"
+                    .formatted(expectedIdValue.toString());
+            final var expectedErrorsCount = 1;
+            final var expectedErrorMessage = expectedExceptionMessage
+                    + ", please close the current channel before publishing the file";
+
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+            final var expectedThroughputLimit = ThroughputLimit.create(100L);
+            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
+                    ParallelChunkLimit.of(2));
+
+            final Publication expectedPublication = null;
+            final var expectedUploadChannel = TransferChannel.create(
+                    expectedThroughputLimit,
+                    expectedChunkSpecification);
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
+
+            final var expectedPublicationError = Publication.Error.of("pub.error");
+
+            assertFalse(expectedFile.isPublished());
+
+            final var actualException = assertThrows(
+                    FileUploadInProgressException.class,
+                    () -> expectedFile.failPublication(expectedPublicationError));
+
+            final var actualExceptionMessage = actualException.getMessage();
+            final var actualErrors = actualException.getErrors();
+            final var actualErrorsCount = actualException.getErrors().size();
+
+            assertEquals(actualExceptionMessage, expectedExceptionMessage);
+            assertEquals(expectedErrorsCount, actualErrors.size());
+            assertEquals(expectedErrorsCount, actualErrorsCount);
+            assertEquals(expectedErrorMessage, actualErrors.get(0).message());
+
+        }
+
+        @Test
+        void givenAValidPublishedFile_whenCallsFailPublicationWithExistingUploadChannel_thenShouldThrowsFileAlreadyPublishedException() {
+
+            final var expectedIdValue = UUID.randomUUID();
+            final var expectedFileId = FileId.of(expectedIdValue);
+            final var expectedSize = new Size(2L);
+
+            final var expectedExceptionMessage = "File [%s], already published"
+                    .formatted(expectedIdValue.toString());
+            final var expectedErrorsCount = 0;
+
+            final var expectedChecksumAlgorithm = Checksum.Algorithm.CRC_32;
+            final var expectedChecksumValue = "123";
+            final var expectedChecksum = Checksum.of(expectedChecksumAlgorithm, expectedChecksumValue);
+
+            final var expectedThroughputLimit = ThroughputLimit.create(100L);
+            final var expectedChunkSpecification = ChunkSpecification.create(Size.of(1024L),
+                    ParallelChunkLimit.of(2));
+
+            final Publication expectedPublication = Publication.ok();
+            final var expectedUploadChannel = TransferChannel.create(
+                    expectedThroughputLimit,
+                    expectedChunkSpecification);
+            final TransferChannel expectedDownloadChannel = null;
+
+            final var expectedFile = File.with(
+                    expectedFileId,
+                    expectedSize,
+                    expectedChecksum,
+                    expectedPublication,
+                    expectedUploadChannel,
+                    expectedDownloadChannel,
+                    null);
+
+            final var expectedPublicationError = Publication.Error.of("pub.error");
+
+            assertTrue(expectedFile.isPublished());
+
+            final var actualException = assertThrows(
+                    FileAlreadyPublishedException.class,
+                    () -> expectedFile.failPublication(expectedPublicationError));
+
+            final var actualExceptionMessage = actualException.getMessage();
+            final var actualErrors = actualException.getErrors();
+            final var actualErrorsCount = actualException.getErrors().size();
+
+            assertEquals(actualExceptionMessage, expectedExceptionMessage);
+            assertEquals(expectedErrorsCount, actualErrors.size());
+            assertEquals(expectedErrorsCount, actualErrorsCount);
+
+        }
 
     }
 

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/FileTest.java
@@ -47,7 +47,7 @@ public class FileTest {
                         expectedFileId,
                         expectedSize,
                         expectedChecksum,
-                        false,
+                        null,
                         expectedUploadChannel,
                         expectedDownloadChannel,
                         null));
@@ -82,7 +82,7 @@ public class FileTest {
                         expectedFileId,
                         expectedSize,
                         expectedChecksum,
-                        false,
+                        null,
                         expectedUploadChannel,
                         expectedDownloadChannel,
                         null));
@@ -112,7 +112,7 @@ public class FileTest {
                         expectedFileId,
                         expectedSize,
                         expectedChecksum,
-                        false,
+                        null,
                         expectedUploadChannel,
                         expectedDownloadChannel,
                         null));
@@ -149,7 +149,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
-                false,
+                null,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);
@@ -190,7 +190,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
-                false,
+                null,
                 null,
                 expectedDownloadChannel,
                 null);
@@ -226,7 +226,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
-                false,
+                null,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);
@@ -276,7 +276,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
-                false,
+                null,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);
@@ -365,7 +365,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
-                false,
+                null,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);
@@ -402,7 +402,7 @@ public class FileTest {
                 expectedFileId,
                 expectedSize,
                 expectedChecksum,
-                false,
+                null,
                 expectedUploadChannel,
                 expectedDownloadChannel,
                 null);

--- a/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/PublicationTest.java
+++ b/domain/src/test/java/org/osnormais/storage/api/domain/file/valueobject/PublicationTest.java
@@ -1,0 +1,231 @@
+package org.osnormais.storage.api.domain.file.valueobject;
+
+import static java.util.Objects.nonNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.osnormais.storage.api.domain.validation.handler.Notification;
+
+class PublicationTest {
+
+    @Nested
+    class Ok {
+
+        @Test
+        void givenNothing_whenCallsOk_thenShouldCreateAnOkPublication() {
+
+            final var expectedPublicationStatus = Publication.Status.OK;
+            final var expectedPublicationError = Optional.<Publication.Error>empty();
+
+            final var actualPublication = assertDoesNotThrow(() -> Publication.ok());
+
+            assertTrue(nonNull(actualPublication.publishedAt()));
+            assertEquals(expectedPublicationStatus, actualPublication.status());
+            assertEquals(expectedPublicationError, actualPublication.error());
+
+        }
+
+    }
+
+    @Nested
+    class Error {
+
+        @Test
+        void givenAValidPublicationError_whenCallsError_thenShouldCreateAnErrorPublication() {
+
+            final var expectedPublicationStatus = Publication.Status.ERROR;
+            final var expectedPublicationError = Optional.of(new Publication.Error("An error occurred"));
+
+            final var actualPublication = assertDoesNotThrow(
+                    () -> Publication.error(Publication.Error.of("An error occurred")));
+
+            assertTrue(nonNull(actualPublication.publishedAt()));
+            assertEquals(expectedPublicationStatus, actualPublication.status());
+            assertEquals(expectedPublicationError, actualPublication.error());
+
+        }
+
+    }
+
+    @Nested
+    class Validate {
+
+        @Test
+        void givenValidPublication_whenValidate_thenShouldNotAppendValidationError() {
+
+            final var expectedValidationErrorsCount = 0;
+
+            final var handler = Notification.create();
+            final var actualPublication = Publication.ok();
+
+            assertDoesNotThrow(() -> actualPublication.validate(handler));
+
+            assertEquals(expectedValidationErrorsCount, handler.getErrors().size());
+
+        }
+
+        @Test
+        void givenNullPublishedAt_whenValidate_thenShouldAppendValidationError() {
+
+            final var expectedValidationErrorsCount = 1;
+            final var expectedValidationErrorMessage0 = "Publication.publishedAt should not be null";
+
+            final Instant expectedPublicationPublishedAt = null;
+
+            final var handler = Notification.create();
+            final var actualPublication = new Publication(
+                    expectedPublicationPublishedAt,
+                    Publication.Status.OK,
+                    Optional.empty());
+
+            assertDoesNotThrow(() -> actualPublication.validate(handler));
+
+            assertEquals(expectedPublicationPublishedAt, actualPublication.publishedAt());
+            assertEquals(expectedValidationErrorsCount, handler.getErrors().size());
+            assertEquals(expectedValidationErrorMessage0, handler.getErrors().get(0).message());
+
+        }
+
+        @Test
+        void givenNullStatus_whenValidate_thenShouldAppendValidationError() {
+
+            final var expectedValidationErrorsCount = 1;
+            final var expectedValidationErrorMessage0 = "Publication.status should not be null";
+
+            final Publication.Status expectedPublicationStatus = null;
+
+            final var handler = Notification.create();
+            final var actualPublication = new Publication(
+                    Instant.now(),
+                    expectedPublicationStatus,
+                    Optional.empty());
+
+            assertDoesNotThrow(() -> actualPublication.validate(handler));
+
+            assertEquals(expectedPublicationStatus, actualPublication.status());
+            assertEquals(expectedValidationErrorsCount, handler.getErrors().size());
+            assertEquals(expectedValidationErrorMessage0, handler.getErrors().get(0).message());
+
+        }
+
+        @Test
+        void givenAnEmptyErrorWithErrorStatus_whenValidate_thenShouldAppendValidationError() {
+
+            final var expectedValidationErrorsCount = 1;
+            final var expectedValidationErrorMessage0 = "Publication.error should not be null when status is ERROR";
+
+            final Publication.Status expectedPublicationStatus = Publication.Status.ERROR;
+
+            final var handler = Notification.create();
+            final var actualPublication = new Publication(
+                    Instant.now(),
+                    expectedPublicationStatus,
+                    Optional.empty());
+
+            assertDoesNotThrow(() -> actualPublication.validate(handler));
+
+            assertEquals(expectedPublicationStatus, actualPublication.status());
+            assertEquals(expectedValidationErrorsCount, handler.getErrors().size());
+            assertEquals(expectedValidationErrorMessage0, handler.getErrors().get(0).message());
+
+        }
+
+        @Test
+        void givenPopulatedErrorWithOKStatus_whenValidate_thenShouldAppendValidationError() {
+
+            final var expectedValidationErrorsCount = 1;
+            final var expectedValidationErrorMessage0 = "Publication.error should be empty when status is OK";
+
+            final Publication.Status expectedPublicationStatus = Publication.Status.OK;
+
+            final var handler = Notification.create();
+            final var actualPublication = new Publication(
+                    Instant.now(),
+                    expectedPublicationStatus,
+                    Optional.of(Publication.Error.of("error")));
+
+            assertDoesNotThrow(() -> actualPublication.validate(handler));
+
+            assertEquals(expectedPublicationStatus, actualPublication.status());
+            assertEquals(expectedValidationErrorsCount, handler.getErrors().size());
+            assertEquals(expectedValidationErrorMessage0, handler.getErrors().get(0).message());
+
+        }
+
+    }
+
+    @Nested
+    class PublicationError {
+
+        @Nested
+        class Of {
+
+            @Test
+            void givenAValidMessage_whenCallsOf_thenShouldCreateAPublicationError() {
+
+                final var expectedPublicationStatus = Publication.Status.ERROR;
+                final var expectedPublicationError = Optional.of(new Publication.Error("An error occurred"));
+
+                final var actualPublication = assertDoesNotThrow(
+                        () -> Publication.error(Publication.Error.of("An error occurred")));
+
+                assertTrue(nonNull(actualPublication.publishedAt()));
+                assertEquals(expectedPublicationStatus, actualPublication.status());
+                assertEquals(expectedPublicationError, actualPublication.error());
+
+            }
+
+        }
+
+        @Nested
+        class Validate {
+
+            @Test
+            void givenNullMessage_whenValidate_thenShouldAppendValidationError() {
+
+                final var expectedValidationErrorsCount = 1;
+                final var expectedValidationErrorMessage0 = "Publication.Error.message should not be null";
+
+                final String expectedPublicationErrorMessage = null;
+
+                final var handler = Notification.create();
+                final var actualPublicationError = new Publication.Error(expectedPublicationErrorMessage);
+
+                assertDoesNotThrow(() -> actualPublicationError.validate(handler));
+
+                assertEquals(expectedPublicationErrorMessage, actualPublicationError.message());
+                assertEquals(expectedValidationErrorsCount, handler.getErrors().size());
+                assertEquals(expectedValidationErrorMessage0, handler.getErrors().get(0).message());
+
+            }
+
+            @Test
+            void givenBlankMessage_whenValidate_thenShouldAppendValidationError() {
+
+                final var expectedValidationErrorsCount = 1;
+                final var expectedValidationErrorMessage0 = "Publication.Error.message should not be blank";
+
+                final String expectedPublicationErrorMessage = " ";
+
+                final var handler = Notification.create();
+                final var actualPublicationError = new Publication.Error(expectedPublicationErrorMessage);
+
+                assertDoesNotThrow(() -> actualPublicationError.validate(handler));
+
+                assertEquals(expectedPublicationErrorMessage, actualPublicationError.message());
+                assertEquals(expectedValidationErrorsCount, handler.getErrors().size());
+                assertEquals(expectedValidationErrorMessage0, handler.getErrors().get(0).message());
+
+            }
+
+        }
+
+    }
+
+}

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/commons/FileSystemUtils.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/commons/FileSystemUtils.java
@@ -11,6 +11,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.osnormais.storage.api.infrastructure.exception.InvalidArgumentException;
@@ -87,13 +89,10 @@ public final class FileSystemUtils {
     }
 
     public static void append(
-            final Long startPosition,
             final FileChannel targetChannel,
             final FileChannel sourceChannel) {
 
         try {
-
-            targetChannel.position(startPosition);
 
             Long inputSize = sourceChannel.size();
             Long transferredBytes = 0L;
@@ -108,6 +107,16 @@ public final class FileSystemUtils {
             throw UnexpectedException.with("Failed to append file channels.", e);
         }
 
+    }
+
+    public static Set<Path> listFiles(final Path directory) {
+        try (Stream<Path> walk = Files.walk(directory)) {
+            return walk
+                    .filter(Files::isRegularFile)
+                    .collect(Collectors.toSet());
+        } catch (IOException e) {
+            throw UnexpectedException.with("Failed to list files in directory: " + directory.toString(), e);
+        }
     }
 
 }

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/commons/SequentialIterator.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/commons/SequentialIterator.java
@@ -1,0 +1,85 @@
+package org.osnormais.storage.api.infrastructure.commons;
+
+import static java.util.Objects.isNull;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import org.osnormais.storage.api.infrastructure.exception.InvalidArgumentException;
+
+public final class SequentialIterator<T> implements Iterator<T> {
+
+    private final ConcurrentHashMap<Long, T> items;
+    private AtomicLong actualPosition;
+
+    private SequentialIterator(final Set<Item<T>> items) {
+
+        validate(items);
+
+        this.actualPosition = new AtomicLong(0L);
+        this.items = new ConcurrentHashMap<>(
+                items
+                        .stream()
+                        .collect(Collectors
+                                .toMap(
+                                        item -> item.position,
+                                        item -> item.value)));
+
+    }
+
+    public static <T> SequentialIterator<T> of(final Set<Item<T>> items) {
+        return new SequentialIterator<>(items);
+    }
+
+    public boolean hasNext() {
+        return items.containsKey(actualPosition.get());
+    }
+
+    public T next() {
+        final Long position = actualPosition.getAndIncrement();
+        final T item = items.get(position);
+        if (isNull(item))
+            throw new IllegalStateException("No more items available at position: " + position);
+        return item;
+    }
+
+    public Long currentPosition() {
+        return actualPosition.longValue();
+    }
+
+    public static record Item<T>(T value, Long position) {
+
+        public static <T> Item<T> of(final T value, final Long position) {
+            return new Item<>(value, position);
+        }
+
+    }
+
+    private static <T> void validate(final Set<Item<T>> items) {
+
+        if (isNull(items) || items.isEmpty())
+            throw InvalidArgumentException.with("Items cannot be null or empty.");
+
+        final List<Long> positions = items.stream()
+                .map(Item::position)
+                .sorted()
+                .toList();
+
+        for (int i = 1; i < positions.size(); i++) {
+            final long expected = positions.get(i - 1) + 1;
+            if (positions.get(i) != expected) {
+                throw InvalidArgumentException.with(
+                        "Invalid sequence. Expected position "
+                                + expected
+                                + " but found "
+                                + positions.get(i));
+            }
+        }
+
+    }
+
+}

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/commons/SequentialIterator.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/commons/SequentialIterator.java
@@ -2,6 +2,7 @@ package org.osnormais.storage.api.infrastructure.commons;
 
 import static java.util.Objects.isNull;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -20,7 +21,6 @@ public final class SequentialIterator<T> implements Iterator<T> {
 
         validate(items);
 
-        this.actualPosition = new AtomicLong(0L);
         this.items = new ConcurrentHashMap<>(
                 items
                         .stream()
@@ -28,6 +28,13 @@ public final class SequentialIterator<T> implements Iterator<T> {
                                 .toMap(
                                         item -> item.position,
                                         item -> item.value)));
+
+        this.actualPosition = new AtomicLong(
+                items
+                        .stream()
+                        .map(Item::position)
+                        .min(Comparator.naturalOrder())
+                        .orElse(0L));
 
     }
 

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/configuration/application/usecase/FileUseCaseConfig.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/configuration/application/usecase/FileUseCaseConfig.java
@@ -6,10 +6,13 @@ import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
 import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
 import org.osnormais.storage.api.application.port.ChunkWriter;
 import org.osnormais.storage.api.application.port.ConcurrencyTracker;
+import org.osnormais.storage.api.application.port.FileFinalizer;
 import org.osnormais.storage.api.application.usecase.file.chunk.upload.DefaultUploadFileChunkUseCase;
 import org.osnormais.storage.api.application.usecase.file.chunk.upload.UploadFileChunkUseCase;
 import org.osnormais.storage.api.application.usecase.file.create.CreateFileUseCase;
 import org.osnormais.storage.api.application.usecase.file.create.DefaultCreateFileUseCase;
+import org.osnormais.storage.api.application.usecase.file.finalize.DefaultFinalizeFileUseCase;
+import org.osnormais.storage.api.application.usecase.file.finalize.FinalizeFileUseCase;
 import org.osnormais.storage.api.application.usecase.file.transferchannel.upload.complete.CompleteFileUploadTransferChannelUseCase;
 import org.osnormais.storage.api.application.usecase.file.transferchannel.upload.complete.DefaultCompleteFileUploadTransferChannelUseCase;
 import org.osnormais.storage.api.application.usecase.file.transferchannel.upload.create.CreateFileUploadTransferChannelUseCase;
@@ -25,6 +28,7 @@ public class FileUseCaseConfig {
     private final FileQueryGateway fileQueryGateway;
     private final ConcurrencyTracker.Port concurrencyTrackerPort;
     private final ChunkWriter chunkWriter;
+    private final FileFinalizer fileFinalizer;
     private final DomainEventDispatcher domainEventDispatcher;
 
     public FileUseCaseConfig(
@@ -32,11 +36,13 @@ public class FileUseCaseConfig {
             final FileQueryGateway fileQueryGateway,
             final ConcurrencyTracker.Port concurrencyTrackerPort,
             final ChunkWriter chunkWriter,
+            final FileFinalizer fileFinalizer,
             final DomainEventDispatcher domainEventDispatcher) {
         this.fileCommandGateway = requireNonNull(fileCommandGateway);
         this.fileQueryGateway = requireNonNull(fileQueryGateway);
         this.concurrencyTrackerPort = requireNonNull(concurrencyTrackerPort);
         this.chunkWriter = requireNonNull(chunkWriter);
+        this.fileFinalizer = requireNonNull(fileFinalizer);
         this.domainEventDispatcher = requireNonNull(domainEventDispatcher);
     }
 
@@ -64,6 +70,14 @@ public class FileUseCaseConfig {
                 fileQueryGateway,
                 fileCommandGateway,
                 domainEventDispatcher);
+    }
+
+    @Bean
+    FinalizeFileUseCase finalizeFileUseCase() {
+        return new DefaultFinalizeFileUseCase(
+                fileQueryGateway,
+                fileCommandGateway,
+                fileFinalizer);
     }
 
 }

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/configuration/application/usecase/FileUseCaseConfig.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/configuration/application/usecase/FileUseCaseConfig.java
@@ -77,7 +77,8 @@ public class FileUseCaseConfig {
         return new DefaultFinalizeFileUseCase(
                 fileQueryGateway,
                 fileCommandGateway,
-                fileFinalizer);
+                fileFinalizer,
+                domainEventDispatcher);
     }
 
 }

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/configuration/messaging/MessageConsumerConfig.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/configuration/messaging/MessageConsumerConfig.java
@@ -2,6 +2,7 @@ package org.osnormais.storage.api.infrastructure.configuration.messaging;
 
 import java.util.function.Consumer;
 
+import org.osnormais.storage.api.application.usecase.file.finalize.FinalizeFileUseCase;
 import org.osnormais.storage.api.infrastructure.file.data.message.FileUploadTransferChannelCompletedMessage;
 import org.osnormais.storage.api.infrastructure.messaging.consumer.rabbitmq.file.FileUploadTransferChannelCompletedConsumer;
 import org.osnormais.storage.api.infrastructure.messaging.producer.MessageProducer;
@@ -17,8 +18,12 @@ public class MessageConsumerConfig {
     @Bean
     Consumer<Message<FileUploadTransferChannelCompletedMessage>> fileUploadTransferChannelCompletedConsumer(
             @Value("${application.messaging.consumer.file-upload-transfer-channel-completed.max-attempts}") final Long maxAttempts,
-            @Qualifier("fileUploadTransferChannelCompletedError") final MessageProducer<FileUploadTransferChannelCompletedMessage> errorMessageProducer) {
-        return new FileUploadTransferChannelCompletedConsumer(maxAttempts, errorMessageProducer);
+            @Qualifier("fileUploadTransferChannelCompletedError") final MessageProducer<FileUploadTransferChannelCompletedMessage> errorMessageProducer,
+            final FinalizeFileUseCase finalizeFileUseCase) {
+        return new FileUploadTransferChannelCompletedConsumer(
+                maxAttempts,
+                errorMessageProducer,
+                finalizeFileUseCase);
     }
 
 }

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/configuration/storage/StorageFileFinalizerConfig.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/configuration/storage/StorageFileFinalizerConfig.java
@@ -1,0 +1,20 @@
+package org.osnormais.storage.api.infrastructure.configuration.storage;
+
+import org.osnormais.storage.api.application.port.FileFinalizer;
+import org.osnormais.storage.api.infrastructure.storage.StorageChecksumProvider;
+import org.osnormais.storage.api.infrastructure.storage.StorageFileAssembler;
+import org.osnormais.storage.api.infrastructure.storage.StorageFileFinalizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StorageFileFinalizerConfig {
+
+    @Bean
+    FileFinalizer fileFinalizer(
+            final StorageFileAssembler assembler,
+            final StorageChecksumProvider checksumProvider) {
+        return new StorageFileFinalizer(assembler, checksumProvider);
+    }
+
+}

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/exception/UnexpectedException.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/exception/UnexpectedException.java
@@ -6,6 +6,10 @@ public class UnexpectedException extends InfrastructureException {
         super(message, cause);
     }
 
+    public static UnexpectedException with(final String message) {
+        return new UnexpectedException(message, null);
+    }
+
     public static UnexpectedException with(final Throwable cause) {
         return new UnexpectedException(cause.getMessage(), cause);
     }

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/messaging/consumer/rabbitmq/file/FileUploadTransferChannelCompletedConsumer.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/messaging/consumer/rabbitmq/file/FileUploadTransferChannelCompletedConsumer.java
@@ -1,7 +1,11 @@
 package org.osnormais.storage.api.infrastructure.messaging.consumer.rabbitmq.file;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Set;
 
+import org.osnormais.storage.api.application.usecase.file.finalize.FinalizeFileInput;
+import org.osnormais.storage.api.application.usecase.file.finalize.FinalizeFileUseCase;
 import org.osnormais.storage.api.infrastructure.file.data.message.FileUploadTransferChannelCompletedMessage;
 import org.osnormais.storage.api.infrastructure.messaging.consumer.rabbitmq.RabbitMQMessageConsumer;
 import org.osnormais.storage.api.infrastructure.messaging.producer.MessageProducer;
@@ -10,15 +14,22 @@ import org.springframework.messaging.Message;
 public class FileUploadTransferChannelCompletedConsumer
         extends RabbitMQMessageConsumer<FileUploadTransferChannelCompletedMessage> {
 
+    private final FinalizeFileUseCase finalizeFileUseCase;
+
     public FileUploadTransferChannelCompletedConsumer(
             final Long maxRetryAttempts,
-            final MessageProducer<FileUploadTransferChannelCompletedMessage> errorMessageProducer) {
+            final MessageProducer<FileUploadTransferChannelCompletedMessage> errorMessageProducer,
+            final FinalizeFileUseCase finalizeFileUseCase) {
         super(maxRetryAttempts, errorMessageProducer, Set.of());
+        this.finalizeFileUseCase = requireNonNull(finalizeFileUseCase);
     }
 
     @Override
     public void consume(final Message<FileUploadTransferChannelCompletedMessage> message) {
-        System.out.println("Received message: " + message.getPayload());
+
+        finalizeFileUseCase
+                .execute(new FinalizeFileInput(message.getPayload().fileId()));
+
     }
 
 }

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/ChunkStorageWriter.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/ChunkStorageWriter.java
@@ -27,7 +27,7 @@ public class ChunkStorageWriter implements ChunkWriter {
             InputStream inputStream) {
 
         final StorageKey chunkStorageKey = StorageKey
-                .create("files", key.getStringValue())
+                .create(key.getStringValue())
                 .subKey(
                         "upload",
                         "chunks",

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/StorageChecksumProvider.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/StorageChecksumProvider.java
@@ -1,0 +1,10 @@
+package org.osnormais.storage.api.infrastructure.storage;
+
+import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+
+@FunctionalInterface
+public interface StorageChecksumProvider {
+
+    Checksum calculateChecksum(StorageKey key, Checksum.Algorithm algorithm);
+
+}

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/StorageFileAssembler.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/StorageFileAssembler.java
@@ -1,0 +1,8 @@
+package org.osnormais.storage.api.infrastructure.storage;
+
+@FunctionalInterface
+public interface StorageFileAssembler {
+
+    void assemble(StorageKey key, Long fileSize);
+
+}

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/StorageFileFinalizer.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/StorageFileFinalizer.java
@@ -1,0 +1,35 @@
+package org.osnormais.storage.api.infrastructure.storage;
+
+import static java.util.Objects.requireNonNull;
+
+import org.osnormais.storage.api.application.port.FileFinalizer;
+import org.osnormais.storage.api.domain.file.File;
+import org.osnormais.storage.api.domain.file.valueobject.Checksum;
+import org.osnormais.storage.api.domain.file.valueobject.Size;
+
+public class StorageFileFinalizer implements FileFinalizer {
+
+    private final StorageFileAssembler assembler;
+    private final StorageChecksumProvider checksumProvider;
+
+    public StorageFileFinalizer(
+            final StorageFileAssembler assembler,
+            final StorageChecksumProvider checksumProvider) {
+        this.assembler = requireNonNull(assembler);
+        this.checksumProvider = requireNonNull(checksumProvider);
+    }
+
+    @Override
+    public Checksum finalize(final File file) {
+
+        final StorageKey storageKey = StorageKey.of(file.getId().getStringValue());
+        final Size fileSize = file.getSize();
+        final Checksum.Algorithm checksumAlgorithm = file.getChecksum().algorithm();
+
+        assembler.assemble(storageKey, fileSize.bytes());
+
+        return checksumProvider.calculateChecksum(storageKey, checksumAlgorithm);
+
+    }
+
+}

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/StorageService.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/StorageService.java
@@ -1,5 +1,8 @@
 package org.osnormais.storage.api.infrastructure.storage;
 
-public interface StorageService extends StorageWriter {
+public interface StorageService extends
+        StorageWriter,
+        StorageFileAssembler,
+        StorageChecksumProvider {
 
 }

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/filesystem/FileSystemStorageService.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/filesystem/FileSystemStorageService.java
@@ -83,13 +83,14 @@ public class FileSystemStorageService implements StorageService {
 
                 final Long chunkPosition = iterator.currentPosition();
                 final Path chunkPath = iterator.next();
+
+                if (!FileSystemUtils.exists(chunkPath))
+                    continue;
+
                 final Long chunkSize = Files.size(chunkPath);
                 final Long offset = calculateOffset(chunkSize, chunkPosition, fileSize);
 
                 outputChannel.position(offset);
-
-                if (!FileSystemUtils.exists(chunkPath))
-                    continue;
 
                 try (final FileChannel inputChannel = FileSystemUtils.openChannel(chunkPath, StandardOpenOption.READ)) {
                     FileSystemUtils.append(outputChannel, inputChannel);

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/filesystem/FileSystemStorageService.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/filesystem/FileSystemStorageService.java
@@ -6,14 +6,20 @@ import static org.osnormais.storage.api.infrastructure.commons.InputStreamUtils.
 import static org.osnormais.storage.api.infrastructure.commons.InputStreamUtils.throttled;
 
 import java.io.InputStream;
+import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.osnormais.storage.api.domain.file.valueobject.Checksum;
 import org.osnormais.storage.api.domain.file.valueobject.Checksum.Algorithm;
 import org.osnormais.storage.api.infrastructure.commons.FileSystemUtils;
+import org.osnormais.storage.api.infrastructure.commons.InputStreamUtils;
 import org.osnormais.storage.api.infrastructure.commons.MessageDigestUtils;
+import org.osnormais.storage.api.infrastructure.commons.SequentialIterator;
 import org.osnormais.storage.api.infrastructure.commons.StringUtils;
 import org.osnormais.storage.api.infrastructure.exception.UnexpectedException;
 import org.osnormais.storage.api.infrastructure.storage.StorageKey;
@@ -50,6 +56,80 @@ public class FileSystemStorageService implements StorageService {
 
         return new Checksum(checksumAlgorithm, StringUtils.toHexString(digest.digest()));
 
+    }
+
+    @Override
+    public void assemble(final StorageKey key, final Long fileSize) {
+
+        final StorageKey finalFileKey = key.subKey("data");
+
+        final Set<SequentialIterator.Item<Path>> items = FileSystemUtils
+                .listFiles(toPath(key))
+                .stream()
+                .map(chunkPath -> SequentialIterator.Item
+                        .of(chunkPath, Long.valueOf(chunkPath.getFileName().toString())))
+                .collect(Collectors.toSet());
+
+        final SequentialIterator<Path> iterator = SequentialIterator.of(items);
+
+        try (final FileChannel outputChannel = FileSystemUtils.openChannel(
+                toPath(finalFileKey),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.APPEND)) {
+
+            while (iterator.hasNext()) {
+
+                final Path chunkPath = iterator.next();
+
+                if (!FileSystemUtils.exists(chunkPath))
+                    continue;
+
+                try (final FileChannel inputChannel = FileSystemUtils.openChannel(chunkPath, StandardOpenOption.READ)) {
+                    FileSystemUtils.append(outputChannel, inputChannel);
+                }
+
+                FileSystemUtils.delete(chunkPath);
+            }
+
+        } catch (Exception e) {
+            throw UnexpectedException.with("Failed to assemble file for key: " + key.getFullKey(), e);
+        }
+
+    }
+
+    @Override
+    public Checksum calculateChecksum(final StorageKey key, final Checksum.Algorithm checksumAlgorithm) {
+
+        final StorageKey fileDataKey = key.subKey("data");
+        final Path fileDataPath = toPath(fileDataKey);
+
+        if (!FileSystemUtils.exists(fileDataPath))
+            throw UnexpectedException.with("File data not found for key: " + key.getFullKey());
+
+        final MessageDigest digest = MessageDigestUtils.create(checksumAlgorithm);
+
+        try (final FileChannel fileChannel = FileSystemUtils.openChannel(fileDataPath, StandardOpenOption.READ)) {
+
+            final InputStream digestibleInputStream = InputStreamUtils
+                    .digestible(
+                            FileSystemUtils.read(fileChannel, 0L),
+                            digest);
+
+            byte[] buffer = new byte[8192];
+            while (digestibleInputStream.read(buffer) != -1) {
+                // Reading the stream to calculate the digest
+            }
+
+        } catch (Exception e) {
+            throw UnexpectedException.with("Failed to calculate checksum for key: " + key.getFullKey(), e);
+        }
+
+        return new Checksum(checksumAlgorithm, StringUtils.toHexString(digest.digest()));
+
+    }
+
+    private Path toPath(final StorageKey storageKey) {
+        return rootLocation.resolve(storageKey.getFullKey());
     }
 
     private static void write(

--- a/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/filesystem/FileSystemStorageService.java
+++ b/infrastructure/src/main/java/org/osnormais/storage/api/infrastructure/storage/filesystem/FileSystemStorageService.java
@@ -7,6 +7,7 @@ import static org.osnormais.storage.api.infrastructure.commons.InputStreamUtils.
 
 import java.io.InputStream;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -62,9 +63,10 @@ public class FileSystemStorageService implements StorageService {
     public void assemble(final StorageKey key, final Long fileSize) {
 
         final StorageKey finalFileKey = key.subKey("data");
+        final StorageKey chunksKey = key.subKey("upload", "chunks");
 
         final Set<SequentialIterator.Item<Path>> items = FileSystemUtils
-                .listFiles(toPath(key))
+                .listFiles(toPath(chunksKey))
                 .stream()
                 .map(chunkPath -> SequentialIterator.Item
                         .of(chunkPath, Long.valueOf(chunkPath.getFileName().toString())))
@@ -75,11 +77,16 @@ public class FileSystemStorageService implements StorageService {
         try (final FileChannel outputChannel = FileSystemUtils.openChannel(
                 toPath(finalFileKey),
                 StandardOpenOption.CREATE,
-                StandardOpenOption.APPEND)) {
+                StandardOpenOption.WRITE)) {
 
             while (iterator.hasNext()) {
 
+                final Long chunkPosition = iterator.currentPosition();
                 final Path chunkPath = iterator.next();
+                final Long chunkSize = Files.size(chunkPath);
+                final Long offset = calculateOffset(chunkSize, chunkPosition, fileSize);
+
+                outputChannel.position(offset);
 
                 if (!FileSystemUtils.exists(chunkPath))
                     continue;
@@ -130,6 +137,15 @@ public class FileSystemStorageService implements StorageService {
 
     private Path toPath(final StorageKey storageKey) {
         return rootLocation.resolve(storageKey.getFullKey());
+    }
+
+    private static Long calculateOffset(final Long chunkSize, final Long chunkIndex, final Long fileSize) {
+
+        if (fileSize - ((chunkIndex * chunkSize) + chunkSize) == 0)
+            return fileSize - chunkSize;
+
+        return chunkIndex * chunkSize;
+
     }
 
     private static void write(


### PR DESCRIPTION

## O que faz
- Este PR implementa a finalização do arquivo após o término do upload por chunks.

## O que foi adicionado
- Novo caso de uso de finalização de arquivo.
- Nova porta de aplicação para finalização (montagem + cálculo de checksum).
- Implementação de finalização no storage, com:
   - montagem do arquivo final a partir dos chunks;
   - cálculo do checksum do arquivo montado.
- Integração do consumer de upload concluído para disparar a finalização.
- Evento de domínio de publicação e regra de domínio para publicar o arquivo somente sem upload em progresso.

## Regras e validações aplicadas
- Se o checksum final não bater com o esperado, é lançada exceção de integridade.  
- Não permite publicar arquivo com canal de upload aberto.  
- Após finalizar com sucesso, estado do arquivo é atualizado e persistido.