### PR TITLE
feat: valida throughput limit e chunk specification na criação do canal de upload

### DIFF
--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCase.java
@@ -47,6 +47,8 @@ public class DefaultCreateFileUploadTransferChannelUseCase extends CreateFileUpl
                         chunkSpecificationParallelChunkLimit);
 
         fileId.validate(handler);
+        throughputLimit.validate(handler);
+        chunkSpecification.validate(handler);
 
         if (handler.hasErrors())
             throw ValidationException.with("Invalid input values", handler);
@@ -55,11 +57,7 @@ public class DefaultCreateFileUploadTransferChannelUseCase extends CreateFileUpl
                 .findById(fileId)
                 .orElseThrow(() -> NotFoundException.create(File.class, fileId));
 
-        final TransferChannel transferChannel = handler
-                .validate(() -> file.openUploadChannel(throughputLimit, chunkSpecification));
-
-        if (handler.hasErrors())
-            throw ValidationException.with("Failed to open upload transfer channel", handler);
+        final TransferChannel transferChannel = file.openUploadChannel(throughputLimit, chunkSpecification);
 
         fileCommandGateway.update(file);
 

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/upload/create/DefaultCreateFileUploadTransferChannelUseCaseTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.osnormais.storage.api.application.exception.NotFoundException;
 import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
 import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
+import org.osnormais.storage.api.domain.exception.TransferChannelAlreadyOpennedException;
 import org.osnormais.storage.api.domain.exception.ValidationException;
 import org.osnormais.storage.api.domain.file.File;
 import org.osnormais.storage.api.domain.file.FileId;
@@ -167,9 +168,9 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
     }
 
     @Test
-    void givenAFileWithUploadTransferChannelAlreadyOpen_whenCallsExecute_thenShouldThrowsValidationException() {
+    void givenAFileWithUploadTransferChannelAlreadyOpen_whenCallsExecute_thenShouldThrowsTransferChannelAlreadyOpennedException() {
 
-        final var expectedExceptionMessage = "Failed to open upload transfer channel";
+        final var expectedExceptionMessage = "Transfer channel already open";
         final var expectedErrorsCount = 1;
         final var expectedErrorMessage0 = "Transfer channel already open, please close the current channel before opening a new one";
 
@@ -212,7 +213,8 @@ public class DefaultCreateFileUploadTransferChannelUseCaseTest {
                 expectedChunkBytesSizeValue,
                 expectedMaxParallelChunksValue);
 
-        final var actualException = assertThrows(ValidationException.class, () -> useCase.execute(input));
+        final var actualException = assertThrows(TransferChannelAlreadyOpennedException.class,
+                () -> useCase.execute(input));
 
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals(expectedErrorsCount, actualException.getErrors().size());


### PR DESCRIPTION
## O que faz
- Adiciona validação explícita de throughputLimit e chunkSpecification antes de abrir o canal de upload.
- Mantém validação de fileId e interrompe execução com ValidationException quando houver erro de input.
- Remove o uso de handler.validate na abertura do canal e chama file.openUploadChannel diretamente.
- Ajusta o comportamento esperado para canal já aberto: agora propaga TransferChannelAlreadyOpennedException.
- Atualiza os testes para refletir a nova exceção e mensagem esperada.

## Impacto  
- Regras de entrada ficam validadas de forma mais clara e antecipada.
- Erro de canal já aberto deixa de ser mascarado como ValidationException genérica.