### PR TITLE
feat expõem exceptions de negocio

### DIFF
--- a/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/download/create/DefaultCreateFileDownloadTransferChannelUseCase.java
+++ b/application/src/main/java/org/osnormais/storage/api/application/usecase/file/transferchannel/download/create/DefaultCreateFileDownloadTransferChannelUseCase.java
@@ -44,6 +44,8 @@ public class DefaultCreateFileDownloadTransferChannelUseCase extends CreateFileD
         final ValidationHandler handler = Notification.create();
 
         fileId.validate(handler);
+        throughputLimit.validate(handler);
+        chunkSpecification.validate(handler);
 
         if (handler.hasErrors())
             throw ValidationException.with("Invalid input values", handler);
@@ -52,11 +54,7 @@ public class DefaultCreateFileDownloadTransferChannelUseCase extends CreateFileD
                 .findById(fileId)
                 .orElseThrow(() -> NotFoundException.create(File.class, fileId));
 
-        final TransferChannel transferChannel = handler
-                .validate(() -> file.openDownloadChannel(throughputLimit, chunkSpecification));
-
-        if (handler.hasErrors())
-            throw ValidationException.with("Failed to open download transfer channel", handler);
+        final TransferChannel transferChannel = file.openDownloadChannel(throughputLimit, chunkSpecification);
 
         fileCommandGateway.update(file);
 

--- a/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/download/create/DefaultCreateFileDownloadTransferChannelUseCaseTest.java
+++ b/application/src/test/java/org/osnormais/storage/api/application/usecase/file/transferchannel/download/create/DefaultCreateFileDownloadTransferChannelUseCaseTest.java
@@ -19,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.osnormais.storage.api.application.exception.NotFoundException;
 import org.osnormais.storage.api.application.gateway.file.FileCommandGateway;
 import org.osnormais.storage.api.application.gateway.file.FileQueryGateway;
+import org.osnormais.storage.api.domain.exception.TransferChannelAlreadyOpennedException;
 import org.osnormais.storage.api.domain.exception.ValidationException;
 import org.osnormais.storage.api.domain.file.File;
 import org.osnormais.storage.api.domain.file.FileId;
@@ -172,7 +173,7 @@ public class DefaultCreateFileDownloadTransferChannelUseCaseTest {
     @Test
     void givenAFileWithDownloadTransferChannelAlreadyOpen_whenCallsExecute_thenShouldThrowsValidationException() {
 
-        final var expectedExceptionMessage = "Failed to open download transfer channel";
+        final var expectedExceptionMessage = "Transfer channel already open";
         final var expectedErrorsCount = 1;
         final var expectedErrorMessage0 = "Transfer channel already open, please close the current channel before opening a new one";
 
@@ -218,7 +219,7 @@ public class DefaultCreateFileDownloadTransferChannelUseCaseTest {
                 expectedChunkBytesSizeValue,
                 expectedMaxParallelChunksValue);
 
-        final var actualException = assertThrows(ValidationException.class, () -> useCase.execute(input));
+        final var actualException = assertThrows(TransferChannelAlreadyOpennedException.class, () -> useCase.execute(input));
 
         assertEquals(expectedExceptionMessage, actualException.getMessage());
         assertEquals(expectedErrorsCount, actualException.getErrors().size());


### PR DESCRIPTION
## O que faz
- Adiciona validação explícita de throughputLimit e chunkSpecification antes de abrir o canal de download.
- Mantém validação de fileId e interrompe execução com ValidationException quando houver erro de input.
- Remove o uso de handler.validate na abertura do canal e chama file.openUploadChannel diretamente.
- Ajusta o comportamento esperado para canal já aberto: agora propaga TransferChannelAlreadyOpennedException.
- Atualiza os testes para refletir a nova exceção e mensagem esperada.

## Impacto  
- Regras de entrada ficam validadas de forma mais clara e antecipada.
- Erro de canal já aberto deixa de ser mascarado como ValidationException genérica.